### PR TITLE
Specify default company name and copyright value to include in file documentation header, in StyleCop options

### DIFF
--- a/Project/Src/AddIns/ReSharper/Options/StyleCopOptionsPage.cs
+++ b/Project/Src/AddIns/ReSharper/Options/StyleCopOptionsPage.cs
@@ -116,6 +116,12 @@ namespace StyleCop.ReSharper.Options
             this.AddBoolOption(
                 (StyleCopOptionsSettingsKey options) => options.InsertToDoText,
                 "Insert TODO into headers");
+            this.AddStringOption(
+                (StyleCopOptionsSettingsKey options) => options.DefaultCompanyName,
+                "Default company name:");
+            this.AddStringOption(
+                (StyleCopOptionsSettingsKey options) => options.DefaultCopyrightValue,
+                "Default copyright:");
             this.AddIntOption(
                 (StyleCopOptionsSettingsKey options) => options.DashesCountInFileHeader,
                 "Number of dashes in file header text:");
@@ -195,16 +201,16 @@ namespace StyleCop.ReSharper.Options
             pluginsPath.Change.Advise(
                 lifetime,
                 args =>
+                {
+                    if (!args.HasNew || args.New == null)
                     {
-                        if (!args.HasNew || args.New == null)
-                        {
-                            return;
-                        }
+                        return;
+                    }
 
-                        this.OptionsSettingsSmartContext.StoreOptionsTransactionContext.SetValue(
-                            (StyleCopOptionsSettingsKey options) => options.PluginsPath,
-                            args.New.FullPath);
-                    });
+                    this.OptionsSettingsSmartContext.StoreOptionsTransactionContext.SetValue(
+                        (StyleCopOptionsSettingsKey options) => options.PluginsPath,
+                        args.New.FullPath);
+                });
             return pluginsPath;
         }
     }

--- a/Project/Src/AddIns/ReSharper/Options/StyleCopOptionsSettingsKey.cs
+++ b/Project/Src/AddIns/ReSharper/Options/StyleCopOptionsSettingsKey.cs
@@ -54,6 +54,18 @@ namespace StyleCop.ReSharper.Options
         public int DashesCountInFileHeader { get; set; }
 
         /// <summary>
+        /// Gets or sets the default company name to include into documentation headers
+        /// </summary>
+        [SettingsEntry("", "Default Company Name In File Header")]
+        public string DefaultCompanyName { get; set; }
+
+        /// /// <summary>
+        /// Gets or sets the default copyright value to include into documentation headers
+        /// </summary>
+        [SettingsEntry("", "Default Copyright Value In File Header")]
+        public string DefaultCopyrightValue { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether descriptive text should be inserted into missing documentation headers.
         /// </summary>
         [SettingsEntry(true, "Insert Text Into Documentation")]

--- a/Project/StyleCop.sln
+++ b/Project/StyleCop.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8FBEC870-B153-4917-A53A-9FB8B369FCA4}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
Specify default company name and copyright value to include in file documentation header, in StyleCop options as requested in [https://github.com/StyleCop/StyleCop/issues/39](https://github.com/StyleCop/StyleCop/issues/39)