### PR TITLE
Fixes #51

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ TestBin/
 *.nupkg
 Build.*.err
 Build.*.wrn
+/.vs

--- a/Project/StyleCop.testsettings
+++ b/Project/StyleCop.testsettings
@@ -6,6 +6,9 @@
       <UnitTestRunConfig testTypeId="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b">
         <AssemblyResolution>
           <TestDirectory useLoadContext="true" />
+          <RuntimeResolution>
+            <Directory path="%ProgramFiles(x86)%\Microsoft Visual Studio 2010 SDK\VisualStudioIntegration\Common\Assemblies\v4.0\" includeSubDirectories="true" />
+          </RuntimeResolution>
         </AssemblyResolution>
       </UnitTestRunConfig>
     </TestTypeSpecific>

--- a/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/ElementOrder/ElementOrderStaticsByAccess.cs
+++ b/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/ElementOrder/ElementOrderStaticsByAccess.cs
@@ -2,9 +2,9 @@ namespace ElementOrderStaticsByAccess1
 {
     public class Class1
     {
+        // Correct order.
         public int staticField;
 
-        // Correct order.
         internal static int staticField1;
     }
 
@@ -70,5 +70,43 @@ namespace ElementOrderStaticsByAccess1
         {
             return true;
         }
+    }
+
+    public class Class7
+    {
+        // Incorrect order, but an allowed exclusion for readonly dependency properties pattern.
+        private static readonly DependencyPropertyKey MyPropertyKey =
+            DependencyProperty.RegisterReadOnly("MyProperty", typeof(string), typeof(Class7));
+
+        public static readonly DependencyProperty MyProperty = MyPropertyKey.DependencyProperty;
+    }
+
+    public class Class8
+    {
+        // A more realistic scenario, with unrelated properties above and below the allowed exclusion.
+        public static readonly DependencyProperty UnrelatedProperty =
+            DependencyProperty.Register("UnrelatedProperty", typeof(string), typeof(Class8));
+
+        private static readonly DependencyPropertyKey MyPropertyKey =
+            DependencyProperty.RegisterReadOnly("MyProperty", typeof(string), typeof(Class8));
+
+        public static readonly DependencyProperty MyProperty = MyPropertyKey.DependencyProperty;
+
+        public static readonly DependencyProperty UnrelatedProperty1 =
+            DependencyProperty.Register("UnrelatedProperty1", typeof(string), typeof(Class8));
+    }
+
+    public class Class9
+    {
+        public static readonly DependencyProperty UnrelatedProperty =
+            DependencyProperty.Register("UnrelatedProperty", typeof(string), typeof(Class9));
+
+        private static readonly DependencyPropertyKey MyPropertyKey =
+            DependencyProperty.RegisterReadOnly("MyProperty", typeof(string), typeof(Class9));
+
+        // Normally, this would flag as a violation, but becuase of the special case exclusion for
+        // DependencyPropertyKey, this case would not. On the other hand it is strange to declare 
+        // DependencyPropertyKey and not expose it outside of the class.
+        public static int i = 13;
     }
 }


### PR DESCRIPTION
- Exclude DependencyPropertyKey definition from Rule: SA1202, and related unit tests.
- Minor fix in constructing rule violation string, when static constructors appear after other constructors
- Add VS10 SDK path to test settings file, allowing dependencies to be discovered during test runs.