### PR TITLE
Parser support for Tuple types and literals

### DIFF
--- a/Project/Src/StyleCop.CSharp/CodeLexer.cs
+++ b/Project/Src/StyleCop.CSharp/CodeLexer.cs
@@ -1139,7 +1139,8 @@ namespace StyleCop.CSharp
                 char character = this.codeReader.Peek(index - this.marker.Index);
 
                 // Break if this is not a valid decimal digit or digit separator.
-                if ((character < '0' || character > '9') && character != '_')
+                // '_' is not allowed as the first char following a '.'
+                if ((character < '0' || character > '9') && (character != '_' || index == startIndex))
                 {
                     break;
                 }
@@ -1174,9 +1175,11 @@ namespace StyleCop.CSharp
 
             int startIndex = index;
 
+            char character;
+
             while (true)
             {
-                char character = this.codeReader.Peek(index - this.marker.Index);
+                character = this.codeReader.Peek(index - this.marker.Index);
 
                 // Break if this is not a valid decimal digit or digit separator.
                 // If the digit seperator is the first char, then this is not a number.
@@ -1186,6 +1189,12 @@ namespace StyleCop.CSharp
                 }
 
                 ++index;
+            }
+
+            // If the last character we read is an '_', this is not a number.
+            if (character == '_')
+            {
+                return -1;
             }
 
             // The last index of the number is one less than the current index.
@@ -1805,7 +1814,7 @@ namespace StyleCop.CSharp
             // Make sure a number was found.
             // If we found '_' at the end, then this is not a number.
             // Note that '_' is not allowed at the beginning too, GetPositiveNumber already handle this.
-            // There are other positions where '_' is not allowed (i.e around '.' or in an exponent),
+            // There are other positions where '_' is not allowed (i.e in an exponent),
             // but for parsing purposes, we include those. The compiler will complain anyway.
             if (endIndex >= markerIndex && this.codeReader.Peek(endIndex - markerIndex) != '_')
             {

--- a/Project/Src/StyleCop.CSharp/CodeParser.Elements.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Elements.cs
@@ -694,7 +694,7 @@ namespace StyleCop.CSharp
                         break;
 
                     case SymbolType.Extern:
-
+                        
                         // If the next symbol is 'alias', then this is possibly an extern alias directive.
                         int temp = this.GetNextCodeSymbolIndex(index + 1);
                         if (temp != -1 && this.symbols.Peek(temp).Text == "alias")
@@ -710,8 +710,12 @@ namespace StyleCop.CSharp
                         break;
 
                     case SymbolType.OpenParenthesis:
-                        elementType = ElementType.Method;
-                        loop = false;
+
+                        // If tuple type, and ';' or '=' follows a variable name, then this is a field.
+                        elementType = this.IsTupleType(index - 1, SymbolType.Semicolon, SymbolType.Equals) 
+                            ? ElementType.Field 
+                            : ElementType.Method;
+                        loop = false;                            
                         break;
 
                     case SymbolType.OpenCurlyBracket:

--- a/Project/Src/StyleCop.CSharp/CodeParser.Elements.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Elements.cs
@@ -640,6 +640,9 @@ namespace StyleCop.CSharp
             // Count of open angle brackets that are not closed yet.
             int openAngleBracketsNotClosedCount = 0;
 
+            // Count of possible type type declaration inside generics.
+            int tupleTypeInsideGenericsCount = 0;
+
             // Indicates whether to keep going.
             bool loop = true;
 
@@ -737,12 +740,26 @@ namespace StyleCop.CSharp
                             else
                             {
                                 elementType = ElementType.Method;
-                            }                            
+                            }
+
+                            loop = false;                            
                         }
 
-                        loop = false;                            
+                        tupleTypeInsideGenericsCount++;
                         break;
 
+                    case SymbolType.CloseParenthesis:
+                        // Allow closing parenthesis if we are in generics with tuple type declaration.
+                        if (tupleTypeInsideGenericsCount > 0)
+                        {
+                            tupleTypeInsideGenericsCount++;
+                        }
+                        else
+                        {
+                            loop = false;
+                        }
+
+                        break;
                     case SymbolType.OpenCurlyBracket:
                         hasCurlyBrackets = true;
                         loop = false;

--- a/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
@@ -630,90 +630,136 @@ namespace StyleCop.CSharp
                     break;
                 }
 
-                Reference<ICodePart> argumentReference = new Reference<ICodePart>();
-
                 if (firstSymbol.SymbolType != SymbolType.Comma)
                 {
-                    // Gather the parameter name label if it exists.
-                    CsToken argumentName = null;
-                    if (firstSymbol.SymbolType == SymbolType.Other)
-                    {
-                        // Look at the next symbol after the label.
-                        int index = this.GetNextCodeSymbolIndex(2);
-                        if (index >= 0)
-                        {
-                            Symbol colon = this.symbols.Peek(index);
-                            if (colon != null && colon.SymbolType == SymbolType.Colon)
-                            {
-                                // This is an argument name label. Add the name label and the colon.
-                                argumentName = this.GetToken(CsTokenType.Other, SymbolType.Other, argumentReference);
-                                this.tokens.Add(argumentName);
-
-                                // The next symbol must be the colon.
-                                this.tokens.Add(this.GetToken(CsTokenType.LabelColon, SymbolType.Colon, argumentReference));
-                            }
-                        }
-                    }
-
-                    // Gather the argument modifiers.
-                    ParameterModifiers modifiers = ParameterModifiers.None;
-
-                    int i = this.GetNextCodeSymbolIndex(1);
-                    if (i >= 0)
-                    {
-                        Symbol symbol = this.symbols.Peek(i);
-
-                        if (symbol.SymbolType == SymbolType.Ref)
-                        {
-                            this.tokens.Add(this.GetToken(CsTokenType.Ref, SymbolType.Ref, argumentReference));
-                            modifiers = ParameterModifiers.Ref;
-                        }
-                        else if (symbol.SymbolType == SymbolType.Out)
-                        {
-                            this.tokens.Add(this.GetToken(CsTokenType.Out, SymbolType.Out, argumentReference));
-                            modifiers = ParameterModifiers.Out;
-                        }
-                        else if (symbol.SymbolType == SymbolType.Params)
-                        {
-                            this.tokens.Add(this.GetToken(CsTokenType.Params, SymbolType.Params, argumentReference));
-                            modifiers = ParameterModifiers.Params;
-                        }
-                    }
-
-                    // The argument body expression must come next.
-                    Expression argumentExpression = this.GetNextExpression(ExpressionPrecedence.None, argumentReference, unsafeCode);
-
-                    // Create the collection of tokens that form the argument, and strip off whitesace from the beginning and end.
-                    CsTokenList argumentTokenList = new CsTokenList(this.tokens, previousTokenNode.Next, this.tokens.Last);
-                    argumentTokenList.Trim(CsTokenType.EndOfLine, CsTokenType.WhiteSpace);
-
-                    // Create and add the argument.
-                    Argument argument = new Argument(
-                        argumentName,
-                        modifiers,
-                        argumentExpression,
-                        CodeLocation.Join(firstSymbol.Location, argumentExpression.Location),
-                        parentReference,
-                        argumentTokenList,
-                        this.symbols.Generated);
-
-                    argumentReference.Target = argument;
-                    arguments.Add(argument);
+                    arguments.Add(this.GetNextArgument(parentReference, unsafeCode, firstSymbol, false, previousTokenNode));
                 }
 
                 // If the next symbol is a comma, add the comma and proceed.
-                int x = this.GetNextCodeSymbolIndex(1);
-                if (x >= 0)
+                Symbol nextSymbol = this.PeekNextSymbol(SkipSymbols.All, parentReference, true);
+
+                if (nextSymbol?.SymbolType == SymbolType.Comma)
                 {
-                    if (this.symbols.Peek(x).SymbolType == SymbolType.Comma)
-                    {
-                        this.tokens.Add(this.GetToken(CsTokenType.Comma, SymbolType.Comma, parentReference));
-                    }
+                    this.tokens.Add(this.GetToken(CsTokenType.Comma, SymbolType.Comma, parentReference));
                 }
             }
 
             // Trim the list down to a small array before returning it.
             return arguments.ToArray();
+        }
+
+        /// <summary>
+        /// Reads the next Argument expression.
+        /// </summary>
+        /// <param name="parentReference">
+        /// The parent code part.
+        /// </param>
+        /// <param name="unsafeCode">
+        /// Indicates whether the code being parsed resides in an unsafe code block.
+        /// </param>
+        /// <param name="firstSymbol">
+        /// The first symbol of the Argument.
+        /// </param>
+        /// <param name="firstSymbolRead">
+        /// The first symbol was already read.
+        /// </param>
+        /// <param name="previousTokenNode">
+        /// A token node, that was read prior to making this function call.
+        /// </param>
+        /// <returns>
+        /// Returns the next argument in the expression.
+        /// </returns>
+        private Argument GetNextArgument(
+            Reference<ICodePart> parentReference, 
+            bool unsafeCode, 
+            Symbol firstSymbol, 
+            bool firstSymbolRead,
+            Node<CsToken> previousTokenNode)
+        {
+            Param.AssertNotNull(parentReference, nameof(parentReference));
+            Param.Ignore(unsafeCode);
+            Param.AssertNotNull(firstSymbol, nameof(firstSymbol));
+            Param.AssertNotNull(previousTokenNode, nameof(previousTokenNode));
+
+            Reference<ICodePart> argumentReference = new Reference<ICodePart>();
+            ParameterModifiers modifiers = ParameterModifiers.None;
+            CsToken argumentName = null;
+            Symbol symbol = firstSymbol;
+
+            if (firstSymbol.SymbolType == SymbolType.Other)
+            {
+                // Gather the parameter name label if it exists.
+                // Look at the next symbol after the label.
+                int foundPosition;
+                symbol = this.PeekNextSymbolFrom(
+                    firstSymbolRead ? 0 : 1, 
+                    SkipSymbols.All, 
+                    parentReference, 
+                    false, 
+                    out foundPosition);
+
+                if (symbol.SymbolType == SymbolType.Colon)
+                {
+                    // This is an argument name label. Add the name label and the colon.
+                    if (firstSymbolRead)
+                    {
+                        // Aready read the symbol, so it should be the last token.
+                        argumentName = previousTokenNode.Value;
+                    }
+                    else
+                    {
+                        argumentName = this.GetToken(CsTokenType.Other, SymbolType.Other, argumentReference);                        
+                        this.tokens.Add(argumentName);
+                    }
+
+                    // The next symbol must be the colon.
+                    this.tokens.Add(this.GetToken(CsTokenType.LabelColon, SymbolType.Colon, argumentReference));
+
+                    // Reset the symbol used for further processing.
+                    symbol = this.PeekNextSymbol(SkipSymbols.All, parentReference, false);
+                }
+                else
+                {
+                    symbol = firstSymbol;
+                }
+            }
+
+            if (symbol.SymbolType == SymbolType.Ref)
+            {
+                this.tokens.Add(this.GetToken(CsTokenType.Ref, SymbolType.Ref, argumentReference));
+                modifiers = ParameterModifiers.Ref;
+            }
+            else if (symbol.SymbolType == SymbolType.Out)
+            {
+                this.tokens.Add(this.GetToken(CsTokenType.Out, SymbolType.Out, argumentReference));
+                modifiers = ParameterModifiers.Out;
+            }
+            else if (symbol.SymbolType == SymbolType.Params)
+            {
+                this.tokens.Add(this.GetToken(CsTokenType.Params, SymbolType.Params, argumentReference));
+                modifiers = ParameterModifiers.Params;
+            }
+
+            // The argument body expression must come next.
+            Expression argumentExpression = this.GetNextExpression(ExpressionPrecedence.None, argumentReference, unsafeCode);
+
+            // Create the collection of tokens that form the argument, and strip off whitesace from the beginning and end.
+            CsTokenList argumentTokenList = new CsTokenList(this.tokens, previousTokenNode.Next, this.tokens.Last);
+            argumentTokenList.Trim(CsTokenType.EndOfLine, CsTokenType.WhiteSpace);
+
+            // Create the argument.
+            Argument argument = new Argument(
+                argumentName,
+                modifiers,
+                argumentExpression,
+                CodeLocation.Join(firstSymbol.Location, argumentExpression.Location),
+                parentReference,
+                argumentTokenList,
+                this.symbols.Generated);
+
+            // Return the argument.
+            argumentReference.Target = argument;
+            return argument;
         }
 
         /// <summary>
@@ -3141,7 +3187,7 @@ namespace StyleCop.CSharp
             else
             {
                 // This is an expression wrapped in parenthesis.
-                expression = this.GetParenthesizedExpression(unsafeCode);
+                expression = this.GetTupleOrParenthesizedExpression(unsafeCode);
             }
 
             return expression;
@@ -3267,15 +3313,15 @@ namespace StyleCop.CSharp
         }
 
         /// <summary>
-        /// Reads an expression wrapped in parenthesis expression.
+        /// Reads an expression wrapped in parenthesis expression, or a tuple expression.
         /// </summary>
         /// <param name="unsafeCode">
         /// Indicates whether the code being parsed resides in an unsafe code block.
         /// </param>
         /// <returns>
-        /// Returns the expression.
+        /// Returns a TupleExpression or ParenthesizedExpression.
         /// </returns>
-        private ParenthesizedExpression GetParenthesizedExpression(bool unsafeCode)
+        private Expression GetTupleOrParenthesizedExpression(bool unsafeCode)
         {
             Param.Ignore(unsafeCode);
 
@@ -3285,29 +3331,92 @@ namespace StyleCop.CSharp
             Bracket openParenthesis = this.GetBracketToken(CsTokenType.OpenParenthesis, SymbolType.OpenParenthesis, expressionReference);
             Node<CsToken> openParenthesisNode = this.tokens.InsertLast(openParenthesis);
 
-            // Get the inner expression.
-            Expression innerExpression = this.GetNextExpression(ExpressionPrecedence.None, expressionReference, unsafeCode);
+            // Get the first expression.
+            Expression firstExpression = this.GetNextExpression(ExpressionPrecedence.None, expressionReference, unsafeCode);
 
-            if (innerExpression == null)
+            if (firstExpression == null)
             {
                 throw this.CreateSyntaxException();
             }
 
-            // Get the closing parenthesis.
-            Bracket closeParenthesis = this.GetBracketToken(CsTokenType.CloseParenthesis, SymbolType.CloseParenthesis, expressionReference);
-            Node<CsToken> closeParenthesisNode = this.tokens.InsertLast(closeParenthesis);
+            Bracket closeParenthesis;
+            Node<CsToken> closeParenthesisNode;
+            CsTokenList partialTokens;
+            Expression resultExpression;
 
+            Symbol nextSymbol = this.PeekNextSymbol(SkipSymbols.All, expressionReference, false);
+
+            // If this is a regular parenthesized expression, return it now.
+            if (nextSymbol.SymbolType == SymbolType.CloseParenthesis)
+            {
+                // Get the closing parenthesis.
+                closeParenthesis = this.GetBracketToken(CsTokenType.CloseParenthesis, SymbolType.CloseParenthesis, expressionReference);
+                closeParenthesisNode = this.tokens.InsertLast(closeParenthesis);
+
+                // Create the token list for the expression.
+                partialTokens = new CsTokenList(this.tokens, openParenthesisNode, this.tokens.Last);
+
+                // Create the expression.
+                resultExpression = new ParenthesizedExpression(partialTokens, firstExpression);
+            }
+            else
+            {
+                Argument firstArgument = null;
+
+                // We are parsing a Tuple literal.
+                if (nextSymbol.SymbolType == SymbolType.Comma)
+                {
+                    // We already read the expression, just create an Argument out it.
+                    firstArgument = new Argument(
+                        null,
+                        ParameterModifiers.None,
+                        firstExpression,
+                        firstExpression.Location,
+                        expressionReference,
+                        firstExpression.Tokens,
+                        this.symbols.Generated);
+                    this.tokens.Add(this.GetToken(CsTokenType.Comma, SymbolType.Comma, expressionReference));
+                }
+                else if (nextSymbol.SymbolType == SymbolType.Colon 
+                    && firstExpression.Tokens.First == firstExpression.Tokens.Last)
+                {
+                    // This is a named Argument and we partially read it, discard the firstExpression and read the Argument.
+                    firstArgument = this.GetNextArgument(
+                        expressionReference,
+                        unsafeCode,
+                        this.symbols.Current,
+                        true,
+                        this.tokens.Last.Previous);
+                }
+                else
+                {
+                    this.CreateSyntaxException();                
+                }
+
+                // Get the remaining list of arguments if any.
+                IList<Argument> argumentsList = this.GetArgumentList(SymbolType.CloseParenthesis, expressionReference, unsafeCode);
+
+                // Prepare a new list that includes our first argument.
+                List<Argument> tupleLiteralArguments = new List<Argument> { firstArgument };
+                tupleLiteralArguments.AddRange(argumentsList);
+
+                // Get the closing parenthesis.
+                closeParenthesis = this.GetBracketToken(CsTokenType.CloseParenthesis, SymbolType.CloseParenthesis, expressionReference);
+                closeParenthesisNode = this.tokens.InsertLast(closeParenthesis);
+
+                // Create the token list for the expression.
+                partialTokens = new CsTokenList(this.tokens, openParenthesisNode, this.tokens.Last);
+
+                // Create the expression.
+                resultExpression = new TupleExpression(partialTokens, tupleLiteralArguments.ToArray());                
+            }
+
+            // Link the opening and closing parenthesis and return the expression.
             openParenthesis.MatchingBracketNode = closeParenthesisNode;
             closeParenthesis.MatchingBracketNode = openParenthesisNode;
 
-            // Create the token list for the expression.
-            CsTokenList partialTokens = new CsTokenList(this.tokens, openParenthesisNode, this.tokens.Last);
-
-            // Create and return the expression.
-            ParenthesizedExpression expression = new ParenthesizedExpression(partialTokens, innerExpression);
-            expressionReference.Target = expression;
-
-            return expression;
+            expressionReference.Target = resultExpression;
+            return resultExpression;
         }
 
         /// <summary>

--- a/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
@@ -1904,7 +1904,7 @@ namespace StyleCop.CSharp
 
                     if (nextSymbol.SymbolType == SymbolType.Other)
                     {
-                        matchVariable = this.GetNextExpression(ExpressionPrecedence.Primary, expressionReference, unsafeCode);
+                        matchVariable = this.GetNextExpression(ExpressionPrecedence.Primary, parentReference, unsafeCode);
                     }
                 }
 

--- a/Project/Src/StyleCop.CSharp/CodeParser.Statements.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Statements.cs
@@ -732,10 +732,11 @@ namespace StyleCop.CSharp
                     }
                     else if (symbolType == SymbolType.CloseSquareBracket)
                     {
-                        if (squareBracketCount++ == 0)
-                        {
-                            break;
-                        }
+                        squareBracketCount--;
+                    }
+                    else
+                    {
+                        break;
                     }
                 }
             }

--- a/Project/Src/StyleCop.CSharp/CodeParser.Statements.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Statements.cs
@@ -366,7 +366,7 @@ namespace StyleCop.CSharp
                                 }
                             }
 
-                            if (this.IsLocalFunctionStatement(false, parentReference))
+                            if (this.IsLocalFunctionStatement(false))
                             {
                                 statement = this.ParseLocalFunctionStatement(unsafeCode);
                                 break;
@@ -463,7 +463,7 @@ namespace StyleCop.CSharp
                             break;
 
                         case SymbolType.Ref:
-                            if (this.IsLocalFunctionStatement(true, parentReference))
+                            if (this.IsLocalFunctionStatement(true))
                             {
                                 statement = this.ParseLocalFunctionStatement(unsafeCode);
                             }
@@ -480,12 +480,18 @@ namespace StyleCop.CSharp
                         case SymbolType.This:
                         case SymbolType.Base:
                         case SymbolType.OpenParenthesis:
-                            if (this.IsTupleType(0, SymbolType.Equals))
+                            SymbolType? trailingSymbolType = this.IsTupleType(0);
+
+                            if (trailingSymbolType == null)
+                            {
+                                statement = this.ParseExpressionStatement(unsafeCode);                                                                
+                            }
+                            else if (trailingSymbolType == SymbolType.Semicolon || trailingSymbolType == SymbolType.Equals)
                             {
                                 // Starts with a tuple type, this is a tuple vairable declaration.
                                 statement = this.ParseVariableDeclarationStatement(parentReference, unsafeCode, variables);
                             }
-                            else if (this.IsTupleType(0, SymbolType.OpenParenthesis, SymbolType.LessThan))
+                            else if (trailingSymbolType == SymbolType.OpenParenthesis || trailingSymbolType == SymbolType.LessThan)
                             {
                                 // Local function statement that returns a tuple.
                                 statement = this.ParseLocalFunctionStatement(unsafeCode);
@@ -581,16 +587,12 @@ namespace StyleCop.CSharp
         /// <param name="isRef">
         /// Indicate if the check should be made for ref local function.
         /// </param>
-        /// <param name="parentReference">
-        /// The parent reference of the current statement being inspected.
-        /// </param>
         /// <returns>
         /// True, if the statement is a local function, False if not.
         /// </returns>
-        private bool IsLocalFunctionStatement(bool isRef, Reference<ICodePart> parentReference)
+        private bool IsLocalFunctionStatement(bool isRef)
         {
             Param.Ignore(isRef);
-            Param.AssertNotNull(parentReference, nameof(parentReference));
             SymbolType expectingNextSymbolType = SymbolType.Other;
 
             // If ref, then move past 'ref' + white space which would be the type declaration.
@@ -603,7 +605,7 @@ namespace StyleCop.CSharp
             while (true)
             {
                 // Get the symbol next to the proposed type declaration symbol.
-                Symbol symbol = this.PeekNextSymbolFrom(testPosition, SkipSymbols.WhiteSpace, parentReference, false, out testPosition);
+                Symbol symbol = this.PeekNextSymbolFrom(testPosition, SkipSymbols.WhiteSpace, false, out testPosition);
 
                 // if we found a symbol that could be used as part of type declaration,
                 // reset our expectation symbol, to read past it.
@@ -650,7 +652,7 @@ namespace StyleCop.CSharp
                 }
 
                 // We are at the right place, evaluate our expectation that next symbol is open paranthesis, or <.
-                Symbol nextSymbol = this.PeekNextSymbolFrom(testPosition, SkipSymbols.WhiteSpace, parentReference, false, out testPosition);
+                Symbol nextSymbol = this.PeekNextSymbolFrom(testPosition, SkipSymbols.WhiteSpace, false, out testPosition);
                 return symbol.SymbolType == SymbolType.Other 
                     && (nextSymbol.SymbolType == SymbolType.OpenParenthesis || nextSymbol.SymbolType == SymbolType.LessThan);                    
             }
@@ -661,21 +663,18 @@ namespace StyleCop.CSharp
         /// Also verifies if the symbol trailing the tuple type and name declaration, matches the specified expected symbols.
         /// </summary>
         /// <param name="testPosition">The position at which to test the existence of Tuple type</param>
-        /// <param name="expectedTrailingSymbols">An array of expected trailing symbols after variable/method name declaration.</param>
-        /// <returns>True, if a tuple type and an expected symbol was found, otherwise False.</returns>
-        private bool IsTupleType(int testPosition, params SymbolType[] expectedTrailingSymbols)
+        /// <returns>The token after tuple type and allowed elements, if a Tuple type was found, Otherwise Null.</returns>
+        private SymbolType? IsTupleType(int testPosition)
         {
             Param.AssertGreaterThanOrEqualToZero(testPosition, nameof(testPosition));
-            Param.AssertNotNull(expectedTrailingSymbols, nameof(expectedTrailingSymbols));
 
             bool foundComma = false;
             int parenthesisCount = 0;
-            Reference<ICodePart> parentReference = new Reference<ICodePart>();
             SymbolType symbolType;
 
             while (true)
             {
-                symbolType = this.PeekNextSymbolFrom(testPosition, SkipSymbols.WhiteSpace, parentReference, false, out testPosition).SymbolType;
+                symbolType = this.PeekNextSymbolFrom(testPosition, SkipSymbols.All, false, out testPosition).SymbolType;
 
                 if (symbolType == SymbolType.Other || symbolType == SymbolType.OpenSquareBracket || symbolType == SymbolType.CloseSquareBracket
                     || symbolType == SymbolType.LessThan || symbolType == SymbolType.GreaterThan)
@@ -708,61 +707,48 @@ namespace StyleCop.CSharp
                 }
 
                 // Unexpected symbol.
-                return false;
+                return null;
             }
 
             if (!foundComma)
             {
-                return false;
+                return null;
             }
 
-            // Move past array declaration brackets if any.
-            int priorPosition = testPosition;
-            symbolType = this.PeekNextSymbolFrom(testPosition, SkipSymbols.WhiteSpace, parentReference, false, out testPosition).SymbolType;
+            symbolType = this.PeekNextSymbolFrom(testPosition, SkipSymbols.All, false, out testPosition).SymbolType;
+            int squareBracketCount = 0;
 
+            // Move past array declaration brackets if any.
             if (symbolType == SymbolType.OpenSquareBracket)
             {
-                int squareBracketCount = 1;
+                squareBracketCount = 1;
 
                 while (true)
                 {
-                    symbolType = this.PeekNextSymbolFrom(testPosition, SkipSymbols.WhiteSpace, parentReference, false, out testPosition).SymbolType;
-
+                    symbolType = this.PeekNextSymbolFrom(testPosition, SkipSymbols.All, false, out testPosition).SymbolType;
                     if (symbolType == SymbolType.OpenSquareBracket)
                     {
                         squareBracketCount++;
                     }
                     else if (symbolType == SymbolType.CloseSquareBracket)
                     {
-                        if (--squareBracketCount == 0)
+                        if (squareBracketCount++ == 0)
                         {
                             break;
                         }
                     }
                 }
             }
-            else
+
+            // We should have parsed all brackets. 
+            // The next symbol should be (variable/method name) or a this keyword.
+            if (squareBracketCount == 0 && symbolType != SymbolType.Other && symbolType != SymbolType.This)
             {
-                testPosition = priorPosition;
+                return null;
             }
 
-            // Grab the second symbol from current (to skip the variable/method name declaration), and verify it's type.
-            symbolType = this.PeekNextSymbolFrom(
-                testPosition + 2, 
-                SkipSymbols.WhiteSpace, 
-                parentReference, 
-                false, 
-                out testPosition).SymbolType;
-
-            for (int i = 0; i < expectedTrailingSymbols.Length; i++)
-            {
-                if (expectedTrailingSymbols[i] == symbolType)
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            // Grab the next symbol, and return it's type so caller can further decode the structure.
+            return this.PeekNextSymbolFrom(testPosition, SkipSymbols.All, false, out testPosition).SymbolType;
         }
 
         /// <summary>
@@ -2116,7 +2102,7 @@ namespace StyleCop.CSharp
 
             // Get the variable definition as part of pattern match, if available.
             Expression matchVariable = null;
-            Symbol nextSymbol = this.PeekNextSymbol(SkipSymbols.All, statementReference, unsafeCode);
+            Symbol nextSymbol = this.PeekNextSymbol(SkipSymbols.All, unsafeCode);
 
             if (nextSymbol.SymbolType == SymbolType.Other)
             {
@@ -2126,7 +2112,7 @@ namespace StyleCop.CSharp
 
             // Get the when expression, if available.
             Expression whenExpression = null;
-            nextSymbol = this.PeekNextSymbol(SkipSymbols.All, statementReference, unsafeCode);
+            nextSymbol = this.PeekNextSymbol(SkipSymbols.All, unsafeCode);
 
             if (nextSymbol.SymbolType == SymbolType.Other && nextSymbol.Text == "when")
             {
@@ -2866,7 +2852,7 @@ namespace StyleCop.CSharp
             Node<CsToken> previousToken = this.tokens.Last;
 
             // Check if the method's return type is ref.
-            Symbol nextSymbol = this.PeekNextSymbol(SkipSymbols.All, statementReference, false);
+            Symbol nextSymbol = this.PeekNextSymbol(SkipSymbols.All, false);
             bool returnTypeIsRef = false;
 
             if (nextSymbol.SymbolType == SymbolType.Ref)
@@ -2885,11 +2871,19 @@ namespace StyleCop.CSharp
             // Get the parameter list.
             IList<Parameter> parameters = this.ParseParameterList(statementReference, unsafeCode, SymbolType.OpenParenthesis, false);
 
+            // Check whether there are any type constraint clauses.
+            ICollection<TypeParameterConstraintClause> typeConstraints = null;
+            nextSymbol = this.GetNextSymbol(statementReference);
+            if (nextSymbol.Text == "where")
+            {
+                typeConstraints = this.ParseTypeConstraintClauses(statementReference, unsafeCode);
+            }
+
             // Prepare a partial list of tokens for this statement.
             CsTokenList partialTokens = new CsTokenList(this.tokens, previousToken?.Next ?? this.tokens.First, this.tokens.Last);
 
             // Now get the function body, which could be a block or an expression;
-            nextSymbol = this.PeekNextSymbol(SkipSymbols.All, statementReference, false);
+            nextSymbol = this.PeekNextSymbol(SkipSymbols.All, false);
             LocalFunctionStatement statement = null;
 
             if (nextSymbol.SymbolType == SymbolType.Lambda)
@@ -2904,6 +2898,7 @@ namespace StyleCop.CSharp
                     returnTypeIsRef, 
                     name, 
                     parameters,
+                    typeConstraints,
                     expression);
             }
             else if (nextSymbol.SymbolType == SymbolType.OpenCurlyBracket)
@@ -2915,6 +2910,7 @@ namespace StyleCop.CSharp
                     returnTypeIsRef,
                     name,
                     parameters,
+                    typeConstraints,
                     functionBody);
             }
             else

--- a/Project/Src/StyleCop.CSharp/CodeParser.Symbols.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Symbols.cs
@@ -722,16 +722,29 @@ namespace StyleCop.CSharp
             Param.Ignore(isExpression);
 
             // Collect all tokens up to the first code token and make sure that this is of type Other.
-            this.GetNextSymbol(SymbolType.Other, parentReference);
+            Symbol nextSymbol = this.GetNextSymbol(parentReference);
 
             Reference<ICodePart> typeTokenReference = new Reference<ICodePart>();
 
             // Get the type token.
-            int endIndex;
-            TypeToken token = this.GetTypeTokenAux(typeTokenReference, parentReference, unsafeCode, includeArrayBrackets, isExpression, 1, out endIndex);
-            if (token != null)
+            TypeToken token = null;
+
+            if (nextSymbol.SymbolType == SymbolType.OpenParenthesis)
             {
-                this.symbols.CurrentIndex += endIndex;
+                token = this.GetTupleTypeToken(typeTokenReference, parentReference);
+            }
+            else if (nextSymbol.SymbolType == SymbolType.Other)
+            {
+                int endIndex;
+                token = this.GetTypeTokenAux(typeTokenReference, parentReference, unsafeCode, includeArrayBrackets, isExpression, 1, out endIndex);
+                if (token != null)
+                {
+                    this.symbols.CurrentIndex += endIndex;
+                }
+            }
+            else
+            {
+                this.CreateSyntaxException();
             }
 
             return token;
@@ -1184,6 +1197,129 @@ namespace StyleCop.CSharp
 
             // Create and return the literal expression.
             return new LiteralExpression(partialTokenList, tokenNode);
+        }
+
+        /// <summary>
+        /// Gets a token representing a tuple type.
+        /// </summary>
+        /// <param name="typeTokenReference">
+        /// A reference to the type token.
+        /// </param>
+        /// <param name="parentReference">
+        /// The parent code unit.
+        /// </param>
+        /// <returns>A TypeToken representing the Tuple type.</returns>
+        private TypeToken GetTupleTypeToken(Reference<ICodePart> typeTokenReference, Reference<ICodePart> parentReference)
+        {
+            Param.AssertNotNull(typeTokenReference, nameof(typeTokenReference));
+            Param.AssertNotNull(parentReference, nameof(parentReference));
+
+            // Create a token list to store all the tokens forming the type.
+            MasterList<CsToken> typeTokens = new MasterList<CsToken>();
+
+            Symbol symbol = this.GetNextSymbol(SkipSymbols.All, typeTokenReference);
+
+            // Ensure that we read a open parenthesis.
+            if (symbol.SymbolType != SymbolType.OpenParenthesis)
+            {
+                this.CreateSyntaxException();
+            }
+
+            typeTokens.Add(this.GetBracketToken(CsTokenType.OpenParenthesis, SymbolType.OpenParenthesis, typeTokenReference));
+            int parenthesisCount = 1;
+            
+            while (true)
+            {
+                symbol = this.PeekNextSymbol(SkipSymbols.None, typeTokenReference, false);
+
+                if (symbol.SymbolType == SymbolType.Other)
+                {
+                    typeTokens.Add(this.GetToken(CsTokenType.Other, SymbolType.Other, typeTokenReference));
+                }
+                else if (symbol.SymbolType == SymbolType.Comma)
+                {
+                    typeTokens.Add(this.GetToken(CsTokenType.Comma, SymbolType.Comma, typeTokenReference));
+                }
+                else if (symbol.SymbolType == SymbolType.OpenSquareBracket)
+                {
+                    typeTokens.Add(this.GetBracketToken(CsTokenType.OpenSquareBracket, SymbolType.OpenSquareBracket, typeTokenReference));
+                }
+                else if (symbol.SymbolType == SymbolType.CloseSquareBracket)
+                {
+                    typeTokens.Add(this.GetBracketToken(CsTokenType.CloseSquareBracket, SymbolType.CloseSquareBracket, typeTokenReference));
+                }
+                else if (symbol.SymbolType == SymbolType.LessThan)
+                {
+                    typeTokens.Add(this.GetBracketToken(CsTokenType.OpenGenericBracket, SymbolType.LessThan, typeTokenReference));
+                }
+                else if (symbol.SymbolType == SymbolType.GreaterThan)
+                {
+                    typeTokens.Add(this.GetBracketToken(CsTokenType.CloseGenericBracket, SymbolType.GreaterThan, typeTokenReference));
+                }
+                else if (symbol.SymbolType == SymbolType.WhiteSpace || symbol.SymbolType == SymbolType.EndOfLine || 
+                         symbol.SymbolType == SymbolType.SingleLineComment || symbol.SymbolType == SymbolType.MultiLineComment 
+                         || symbol.SymbolType == SymbolType.PreprocessorDirective)
+                {
+                    typeTokens.Add(this.GetToken(TokenTypeFromSymbolType(symbol.SymbolType), symbol.SymbolType, typeTokenReference));
+                }
+                else if (symbol.SymbolType == SymbolType.OpenParenthesis)
+                {
+                    typeTokens.Add(this.GetBracketToken(CsTokenType.OpenParenthesis, SymbolType.OpenParenthesis, typeTokenReference));
+                    parenthesisCount++;
+                }
+                else if (symbol.SymbolType == SymbolType.CloseParenthesis)
+                {
+                    typeTokens.Add(this.GetBracketToken(CsTokenType.CloseParenthesis, SymbolType.CloseParenthesis, typeTokenReference));
+                    parenthesisCount--;
+                }
+                else
+                {
+                    this.CreateSyntaxException();
+                }
+
+                if (parenthesisCount == 0)
+                {
+                    break;
+                }
+            }
+
+            // Read any array brackets.
+            int startPosition = 0;
+            symbol = this.PeekNextSymbolFrom(startPosition, SkipSymbols.WhiteSpace, parentReference, false, out startPosition);
+
+            if (symbol.SymbolType == SymbolType.OpenSquareBracket)
+            {
+                int squareBracketCount = 1;
+
+                typeTokens.Add(this.GetBracketToken(CsTokenType.OpenSquareBracket, SymbolType.OpenSquareBracket, typeTokenReference));
+                startPosition = 0;
+
+                while (true)
+                {
+                    symbol = this.PeekNextSymbolFrom(startPosition, SkipSymbols.WhiteSpace, parentReference, false, out startPosition);
+
+                    if (symbol.SymbolType == SymbolType.OpenSquareBracket)
+                    {
+                        typeTokens.Add(this.GetBracketToken(CsTokenType.OpenSquareBracket, SymbolType.OpenSquareBracket, typeTokenReference));
+                        squareBracketCount++;
+                    }
+                    else if (symbol.SymbolType == SymbolType.CloseSquareBracket)
+                    {
+                        typeTokens.Add(this.GetBracketToken(CsTokenType.CloseSquareBracket, SymbolType.CloseSquareBracket, typeTokenReference));
+
+                        if (--squareBracketCount == 0)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            CodeLocation location = CsToken.JoinLocations(typeTokens.First, typeTokens.Last);
+            TypeToken typeToken = new TypeToken(typeTokens, location, parentReference, this.symbols.Generated);
+            typeTokenReference.Target = typeToken;
+
+            return typeToken;
         }
 
         /// <summary>

--- a/Project/Src/StyleCop.CSharp/CodeParser.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.cs
@@ -1233,6 +1233,18 @@ namespace StyleCop.CSharp
                         genericArgumentListTokens.Add(
                             this.ConvertSymbol(symbol, symbol.SymbolType == SymbolType.In ? CsTokenType.In : CsTokenType.Out, genericTypeReference));
                     }
+                    else if (symbol.SymbolType == SymbolType.OpenParenthesis)
+                    {
+                        // Tuple type definition is starting.
+                        genericArgumentListTokens.InsertLast(new Bracket(
+                            symbol.Text, CsTokenType.OpenParenthesis, symbol.Location, genericTypeReference, this.symbols.Generated)); 
+                    }
+                    else if (symbol.SymbolType == SymbolType.CloseParenthesis)
+                    {
+                        // Tuple type definition is finishing.
+                        genericArgumentListTokens.InsertLast(new Bracket(
+                            symbol.Text, CsTokenType.CloseParenthesis, symbol.Location, genericTypeReference, this.symbols.Generated)); 
+                    }
                     else if (symbol.SymbolType == SymbolType.Other)
                     {
                         int lastIndex = 0;
@@ -1536,17 +1548,16 @@ namespace StyleCop.CSharp
         /// Returns the next code symbol without advancing to it.
         /// </summary>
         /// <param name="skip">Indicates the types of symbols to skip past.</param>
-        /// <param name="parentReference">The parent code part.</param>
         /// <param name="allowNull">If true, indicates that this method is allowed to return a null symbol, if
         /// there are no more symbols in the document. If false, the method will throw an exception if it is unable
         /// to get another symbol.</param>
         /// <returns>Returns the next code symbol.</returns>
         /// <exception cref="SyntaxException">Will be thrown if there are no more symbols in the document.
         /// </exception>
-        private Symbol PeekNextSymbol(SkipSymbols skip, Reference<ICodePart> parentReference, bool allowNull)
+        private Symbol PeekNextSymbol(SkipSymbols skip, bool allowNull)
         {
             int foundPosition;
-            return this.PeekNextSymbolFrom(0, skip, parentReference, allowNull, out foundPosition);
+            return this.PeekNextSymbolFrom(0, skip, allowNull, out foundPosition);
         }
 
         /// <summary>
@@ -1554,7 +1565,6 @@ namespace StyleCop.CSharp
         /// </summary>
         /// <param name="position">The relative position to current index, from which the next symbol should be peeked.</param>
         /// <param name="skip">Indicates the types of symbols to skip past.</param>
-        /// <param name="parentReference">The parent code part.</param>
         /// <param name="allowNull">If true, indicates that this method is allowed to return a null symbol, if
         /// there are no more symbols in the document. If false, the method will throw an exception if it is unable
         /// to get another symbol.</param>
@@ -1562,11 +1572,10 @@ namespace StyleCop.CSharp
         /// <returns>Returns the next code symbol.</returns>
         /// <exception cref="SyntaxException">Will be thrown if there are no more symbols in the document.
         /// </exception>
-        private Symbol PeekNextSymbolFrom(int position, SkipSymbols skip, Reference<ICodePart> parentReference, bool allowNull, out int foundAtPosition)
+        private Symbol PeekNextSymbolFrom(int position, SkipSymbols skip, bool allowNull, out int foundAtPosition)
         {
             Param.AssertGreaterThanOrEqualToZero(position, nameof(position));
             Param.Ignore(skip);
-            Param.AssertNotNull(parentReference, "parentReference");
 
             int index = position + 1;
             Symbol symbol = this.symbols.Peek(index);

--- a/Project/Src/StyleCop.CSharp/ExpressionType.cs
+++ b/Project/Src/StyleCop.CSharp/ExpressionType.cs
@@ -236,6 +236,11 @@ namespace StyleCop.CSharp
         /// <summary>
         /// A reference value expression. 
         /// </summary>
-        Ref
+        Ref,
+
+        /// <summary>
+        /// A tuple expression.
+        /// </summary>
+        Tuple
     }
 }

--- a/Project/Src/StyleCop.CSharp/Expressions/TupleExpression.cs
+++ b/Project/Src/StyleCop.CSharp/Expressions/TupleExpression.cs
@@ -1,0 +1,73 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TupleExpression.cs" company="https://github.com/StyleCop">
+//   MS-PL
+// </copyright>
+// <license>
+//   This source code is subject to terms and conditions of the Microsoft 
+//   Public License. A copy of the license can be found in the License.html 
+//   file at the root of this distribution. If you cannot locate the  
+//   Microsoft Public License, please send an email to dlr@microsoft.com. 
+//   By using this source code in any fashion, you are agreeing to be bound 
+//   by the terms of the Microsoft Public License. You must not remove this 
+//   notice, or any other, from this software.
+// </license>
+// <summary>
+//   An expression that represents a Tuple literal.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+namespace StyleCop.CSharp
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// An expression that represents a Tuple literal.
+    /// </summary>
+    /// <subcategory>expression</subcategory>
+    public class TupleExpression : Expression
+    {
+        #region Fields
+
+        /// <summary>
+        /// The arguments that form the Tuple expression.
+        /// </summary>
+        private readonly IList<Argument> arguments;
+
+        #endregion
+        
+        #region Constructors and Destructors
+
+        /// <summary>
+        /// Initializes a new instance of the TupleExpression class.
+        /// </summary>
+        /// <param name="tokens">
+        /// The list of tokens that form the expression.
+        /// </param>
+        /// <param name="arguments">
+        /// The arguments that form the Tuple literal.
+        /// </param>
+        internal TupleExpression(CsTokenList tokens, IList<Argument> arguments)
+            : base(ExpressionType.Tuple, tokens)
+        {
+            Param.AssertNotNull(arguments, nameof(arguments));
+            Param.AssertGreaterThanZero(arguments.Count, nameof(arguments));
+
+            this.arguments = arguments;
+
+            for (int i = 0; i < arguments.Count; ++i)
+            {
+                this.AddExpression(arguments[i].Expression);
+            }
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        /// Gets the list of arguments that form the Tuple literal.
+        /// </summary>
+        public IList<Argument> Arguments => this.arguments;
+
+        #endregion
+    }
+}

--- a/Project/Src/StyleCop.CSharp/Statements/LocalFunctionStatement.cs
+++ b/Project/Src/StyleCop.CSharp/Statements/LocalFunctionStatement.cs
@@ -23,7 +23,7 @@ namespace StyleCop.CSharp
     /// A local function within a method element.
     /// </summary>
     /// <subcategory>statement</subcategory>
-    public class LocalFunctionStatement : Statement
+    public class LocalFunctionStatement : Statement, ITypeConstraintContainer
     {
         #region Fields
 
@@ -47,6 +47,11 @@ namespace StyleCop.CSharp
         /// </summary>
         private readonly IList<Parameter> parameters;
 
+        /// <summary>
+        /// The list if type constraints on the item, if any.
+        /// </summary>
+        private readonly ICollection<TypeParameterConstraintClause> typeConstraints;
+        
         /// <summary>
         /// The code unit that represents this local functions body.
         /// </summary>
@@ -74,6 +79,9 @@ namespace StyleCop.CSharp
         /// <param name="parameters">
         /// The parameter information of this local function.
         /// </param>
+        /// <param name="typeConstraints">
+        /// The list of type constraints on the element.
+        /// </param>
         /// <param name="functionBodyExpression">
         /// An expression that represents the body of this local function.
         /// </param>
@@ -83,8 +91,9 @@ namespace StyleCop.CSharp
             bool returnTypeIsRef, 
             LiteralExpression identifier, 
             IList<Parameter> parameters,
+            ICollection<TypeParameterConstraintClause> typeConstraints, 
             Expression functionBodyExpression)
-            : this(tokens, returnType, returnTypeIsRef, identifier, parameters)
+            : this(tokens, returnType, returnTypeIsRef, identifier, parameters, typeConstraints)
         {
             Param.AssertNotNull(functionBodyExpression, nameof(functionBodyExpression));
             this.functionBody = functionBodyExpression;
@@ -109,6 +118,9 @@ namespace StyleCop.CSharp
         /// <param name="parameters">
         /// The parameter information of this local function.
         /// </param>
+        /// <param name="typeConstraints">
+        /// The list of type constraints on the element.
+        /// </param>
         /// <param name="functionBody">
         /// An statement that represents the body of this local function.
         /// </param>
@@ -118,8 +130,9 @@ namespace StyleCop.CSharp
             bool returnTypeIsRef, 
             LiteralExpression identifier, 
             IList<Parameter> parameters,
+            ICollection<TypeParameterConstraintClause> typeConstraints, 
             Statement functionBody)
-            : this(tokens, returnType, returnTypeIsRef, identifier, parameters)
+            : this(tokens, returnType, returnTypeIsRef, identifier, parameters, typeConstraints)
         {
             Param.AssertNotNull(functionBody, nameof(functionBody));
             this.functionBody = functionBody;
@@ -144,25 +157,40 @@ namespace StyleCop.CSharp
         /// <param name="parameters">
         /// The parameter information of this local function.
         /// </param>
+        /// <param name="typeConstraints">
+        /// The list of type constraints on the element.
+        /// </param>
         private LocalFunctionStatement(
             CsTokenList tokens, 
             TypeToken returnType, 
             bool returnTypeIsRef, 
             LiteralExpression identifier, 
-            IList<Parameter> parameters)
+            IList<Parameter> parameters,
+            ICollection<TypeParameterConstraintClause> typeConstraints)
             : base(StatementType.LocalFunction, tokens)
         {
             Param.AssertNotNull(returnType, nameof(returnType));
             Param.Ignore(returnTypeIsRef);
             Param.AssertNotNull(identifier, nameof(identifier));
             Param.AssertNotNull(parameters, nameof(parameters));
+            Param.Ignore(typeConstraints);
 
             this.returnType = returnType;
             this.returnTypeIsRef = returnTypeIsRef;
             this.identifier = identifier;
             this.parameters = parameters;
+            this.typeConstraints = typeConstraints;
 
             this.AddExpression(this.identifier);
+
+            // Set the parent of the type constraint clauses.
+            if (typeConstraints != null)
+            {
+                foreach (TypeParameterConstraintClause constraint in typeConstraints)
+                {
+                    constraint.ParentElement = this;
+                }
+            }
         }
 
         #endregion
@@ -193,6 +221,11 @@ namespace StyleCop.CSharp
         /// Gets the expression or statement that represents the body of this local function.
         /// </summary>
         public CodeUnit FunctionBody => this.functionBody;
+
+        /// <summary>
+        /// Gets the list of type constraints on the element, if any.
+        /// </summary>
+        public ICollection<TypeParameterConstraintClause> TypeConstraints => this.typeConstraints;
 
         #endregion
     }

--- a/Project/Src/StyleCop.CSharp/Statements/LocalFunctionStatement.cs
+++ b/Project/Src/StyleCop.CSharp/Statements/LocalFunctionStatement.cs
@@ -77,7 +77,7 @@ namespace StyleCop.CSharp
         /// <param name="functionBodyExpression">
         /// An expression that represents the body of this local function.
         /// </param>
-        public LocalFunctionStatement(
+        internal LocalFunctionStatement(
             CsTokenList tokens, 
             TypeToken returnType, 
             bool returnTypeIsRef, 
@@ -112,7 +112,7 @@ namespace StyleCop.CSharp
         /// <param name="functionBody">
         /// An statement that represents the body of this local function.
         /// </param>
-        public LocalFunctionStatement(
+        internal LocalFunctionStatement(
             CsTokenList tokens, 
             TypeToken returnType, 
             bool returnTypeIsRef, 

--- a/Project/Src/StyleCop.CSharp/StyleCop.CSharp.csproj
+++ b/Project/Src/StyleCop.CSharp/StyleCop.CSharp.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Expressions\DictionaryItemInitializationExpression.cs" />
     <Compile Include="Expressions\RefExpression.cs" />
     <Compile Include="Expressions\ThrowExpression.cs" />
+    <Compile Include="Expressions\TupleExpression.cs" />
     <Compile Include="ICodePart.cs" />
     <Compile Include="ICodePartExtensions.cs" />
     <Compile Include="ICodeUnit.cs" />

--- a/Project/Src/StyleCop.CSharp/TypeParameterConstraintClause.cs
+++ b/Project/Src/StyleCop.CSharp/TypeParameterConstraintClause.cs
@@ -153,7 +153,7 @@ namespace StyleCop.CSharp
         /// <summary>
         /// Gets the parent element that contains this type constraint.
         /// </summary>
-        public CsElement ParentElement { get; internal set; }
+        public CodeUnit ParentElement { get; internal set; }
 
         /// <summary>
         /// Gets the list of tokens that form the constraint.

--- a/Project/Test/Tests.StyleCop.CSharp/ParserTests.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/ParserTests.cs
@@ -239,6 +239,7 @@ namespace CSharpParserTest
         {
             this.RunTest("PatternMatch");
         }
+
         /// <summary>
         /// The run test.
         /// </summary>

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Field.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Field.cs
@@ -184,6 +184,12 @@ public class BinaryLiteralsAndDigitSeperator
     long longValue2 = 0x1_0000_0000;
 
     long longValue3 = 0b1_0000_0000_0000_0000_0000_0000_0000_0000;
+
+
+    public void RegressionChecksForDigitSeparator()
+    {
+        this._someVariable = new SomeVariableObject(this._somOtherVariable);        
+    }
 }
 
 public class TupleTypes

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Field.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Field.cs
@@ -202,7 +202,7 @@ public class TupleTypes
 
     (List<string> Names, List<double> Scores) tupleTypesWithGenericsAndNames;
 
-    (List<string> , Dictionary<double, List<double>>) tupleTypesWithNestedGenerics;
+    (List<string>, Dictionary<double, List<double>>) tupleTypesWithNestedGenerics;
 
     (List<string> Names, Dictionary<double, List<double>> Scores) tupleTypesWithNestedGenericsAndNames;
 
@@ -224,5 +224,10 @@ public class TupleTypes
 
     (int, string)[] tuppleArrayInitialized = { (1, "One"), (2, "Two") };
 
+    List<(double, string, DateTime)> tupleInsideList;
+
+    List<(string name, DateTime dob)> namedTupleInsideList;
+
+    List<(string, (string, double))> nestedTuplesInsideList;
 }
 

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Field.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Field.cs
@@ -185,3 +185,44 @@ public class BinaryLiteralsAndDigitSeperator
 
     long longValue3 = 0b1_0000_0000_0000_0000_0000_0000_0000_0000;
 }
+
+public class TupleTypes
+{
+    (string, int) simpleTupleType;
+
+    private (string, int) simpleTupleTypeWithScope;
+
+    (string Name, double Age) tupleTypeWithNames;
+
+    (string, double, (string, string)) nestedTupleTypes;
+
+    (string Name, double Age, (string City, string Country)) nestedTupleTypesWithNames;
+
+    (List<string>, List<double>) tupleTypesWithGenerics;
+
+    (List<string> Names, List<double> Scores) tupleTypesWithGenericsAndNames;
+
+    (List<string> , Dictionary<double, List<double>>) tupleTypesWithNestedGenerics;
+
+    (List<string> Names, Dictionary<double, List<double>> Scores) tupleTypesWithNestedGenericsAndNames;
+
+    (string[], double[]) tupleTypesWithArrays;
+
+    (string[] Names, double[] Scores) tupleTypesWithArraysAndNames;
+
+    (string[], double[][]) tupleTypesWithMultiDimensionalArrays;
+
+    (string[] Names, double[][] Scores) tupleTypesWithMultiDimensionalArraysAndNames;
+
+    (List<string>[], List<double[]>) tupleWithMixedArrayAndGenerics;
+
+    (List<string>[] Names, List<double[]> Scores) tupleWithMixedArrayAndGenericsAndNames;
+
+    (int, string) intitializedField = (2, "Two");
+
+    (int, string)[] tupleArray;
+
+    (int, string)[] tuppleArrayInitialized = { (1, "One"), (2, "Two") };
+
+}
+

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/FieldObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/FieldObjectModel.xml
@@ -1150,6 +1150,36 @@
           </Expression>
         </Statement>
       </Element>
+      <Element Name="tupleInsideList" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="List&lt;(double,string,DateTime)&gt;" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tupleInsideList" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="namedTupleInsideList" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="List&lt;(stringname,DateTimedob)&gt;" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="namedTupleInsideList" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="nestedTuplesInsideList" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="List&lt;(string,(string,double))&gt;" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="nestedTuplesInsideList" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
     </Element>
   </Element>
 </StyleCopCsParserObjectModel>

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/FieldObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/FieldObjectModel.xml
@@ -954,6 +954,25 @@
           </Expression>
         </Statement>
       </Element>
+      <Element Name="RegressionChecksForDigitSeparator" Type="Method">
+        <Statement Type="ExpressionStatement">
+          <Expression Type="AssignmentExpression">
+            <Expression Type="MemberAccessExpression">
+              <Expression Text="this" Type="LiteralExpression" />
+              <Expression Text="_someVariable" Type="LiteralExpression" />
+            </Expression>
+            <Expression Type="NewExpression">
+              <Expression Type="MethodInvocationExpression">
+                <Expression Text="SomeVariableObject" Type="LiteralExpression" />
+                <Expression Type="MemberAccessExpression">
+                  <Expression Text="this" Type="LiteralExpression" />
+                  <Expression Text="_somOtherVariable" Type="LiteralExpression" />
+                </Expression>
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
     </Element>
     <Element Name="TupleTypes" Type="Class">
       <Element Name="simpleTupleType" Type="Field">

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/FieldObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/FieldObjectModel.xml
@@ -955,5 +955,201 @@
         </Statement>
       </Element>
     </Element>
+    <Element Name="TupleTypes" Type="Class">
+      <Element Name="simpleTupleType" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(string,int)" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="simpleTupleType" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="simpleTupleTypeWithScope" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(string,int)" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="simpleTupleTypeWithScope" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="tupleTypeWithNames" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(stringName,doubleAge)" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tupleTypeWithNames" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="nestedTupleTypes" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(string,double,(string,string))" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="nestedTupleTypes" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="nestedTupleTypesWithNames" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(stringName,doubleAge,(stringCity,stringCountry))" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="nestedTupleTypesWithNames" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="tupleTypesWithGenerics" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(List&lt;string&gt;,List&lt;double&gt;)" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tupleTypesWithGenerics" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="tupleTypesWithGenericsAndNames" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(List&lt;string&gt;Names,List&lt;double&gt;Scores)" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tupleTypesWithGenericsAndNames" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="tupleTypesWithNestedGenerics" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(List&lt;string&gt;,Dictionary&lt;double,List&lt;double&gt;&gt;)" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tupleTypesWithNestedGenerics" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="tupleTypesWithNestedGenericsAndNames" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(List&lt;string&gt;Names,Dictionary&lt;double,List&lt;double&gt;&gt;Scores)" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tupleTypesWithNestedGenericsAndNames" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="tupleTypesWithArrays" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(string[],double[])" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tupleTypesWithArrays" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="tupleTypesWithArraysAndNames" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(string[]Names,double[]Scores)" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tupleTypesWithArraysAndNames" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="tupleTypesWithMultiDimensionalArrays" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(string[],double[][])" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tupleTypesWithMultiDimensionalArrays" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="tupleTypesWithMultiDimensionalArraysAndNames" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(string[]Names,double[][]Scores)" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tupleTypesWithMultiDimensionalArraysAndNames" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="tupleWithMixedArrayAndGenerics" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(List&lt;string&gt;[],List&lt;double[]&gt;)" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tupleWithMixedArrayAndGenerics" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="tupleWithMixedArrayAndGenericsAndNames" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(List&lt;string&gt;[]Names,List&lt;double[]&gt;Scores)" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tupleWithMixedArrayAndGenericsAndNames" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="intitializedField" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(int,string)" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="intitializedField" Type="LiteralExpression" />
+              <Expression Type="TupleExpression">
+                <Expression Text="2" Type="LiteralExpression" />
+                <Expression Text="&quot;Two&quot;" Type="LiteralExpression" />
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="tupleArray" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(int,string)[]" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tupleArray" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="tuppleArrayInitialized" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(int,string)[]" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tuppleArrayInitialized" Type="LiteralExpression" />
+              <Expression Type="ArrayInitializerExpression">
+                <Expression Type="TupleExpression">
+                  <Expression Text="1" Type="LiteralExpression" />
+                  <Expression Text="&quot;One&quot;" Type="LiteralExpression" />
+                </Expression>
+                <Expression Type="TupleExpression">
+                  <Expression Text="2" Type="LiteralExpression" />
+                  <Expression Text="&quot;Two&quot;" Type="LiteralExpression" />
+                </Expression>
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+    </Element>
   </Element>
 </StyleCopCsParserObjectModel>

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
@@ -262,6 +262,22 @@ public class Class8<T, S>
         public string GetLastName() => throw new NotImplementedException();
     }
 
+    public class Person
+    {
+        private static ConcurrentDictionary<int, string> names = new ConcurrentDictionary<int, string>();
+        private int id = GetId();
+
+        public Person(string name) => names.TryAdd(id, name); // constructors
+
+        ~Person() => names.TryRemove(id, out _);              // finalizers
+
+        public string Name
+        {
+            get => names[id];                                 // getters
+            set => names[id] = value;                         // setters
+        }
+    }
+
 #endregion
 
 #region Ref Returns And Locals
@@ -420,6 +436,27 @@ public class Class8<T, S>
             List<string>[] LocalFunction2()
             {
                 return null;
+            }
+        }
+    }
+
+#endregion
+
+#region Out Variables
+
+    public class OutVariables
+    {
+        public void PrintCoordinates(Point p)
+        {
+            p.GetCoordinates(out int x, out int y);
+            p.GetCoordinates(out var x, out _); // Test for discards.
+        }
+
+        public void PrintStars(string s)
+        {
+            if (int.TryParse(s, out var i))
+            {
+                return;
             }
         }
     }

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
@@ -462,3 +462,63 @@ public class Class8<T, S>
     }
 
 #endregion
+
+#region Tuple literal and Tuple types
+
+    public class Tuples
+    {
+        public void TuplesLiteralsTest()
+        {
+            // Simple tuple literals
+            var letters = ("a", "b");
+
+            // named elements tuple literals
+            var alphabetStart = (Alpha: "a", Beta: "b");
+
+            // tuple literals with member access invocation
+            var dateRange = (DateTime.MinValue, DateTime.MaxValue);
+
+            // tuple literals with method invocation.
+            var caculatedRange = (dates.First(), dates.Last());
+
+            // tuple literal that as casting for a argument
+            var cast = ((string)"a", "b");
+
+            // tuple literal nested in another tuple literal
+            var nested = (("a", 1), DateTime.Now);
+
+            // tuple literals in return statement.
+            return (first, middle, last);
+
+            // named tuple elements in a literal
+            return (first: first, middle: middle, last: last);
+        }
+
+        // tuple return type
+        (string, string, string) TupleTypeTest(long id)
+        {
+            return (first, middle, last); // tuple literal
+        }
+
+        // tuple return type with elements names
+        (string first, string middle, string last) TupleTypeWithNameTest(long id)
+        {
+            return (first, middle, last); // tuple literal
+        }
+
+        // Local function which return tuple types 
+        public int Fibonacci(int x)
+        {
+            if (x < 0) throw new ArgumentException("Less negativity please!", nameof(x));
+            return Fib(x).current;
+
+            (int current, int previous) Fib(int i)
+            {
+                if (i == 0) return (1, 0);
+                var (p, pp) = Fib(i - 1);
+                return (p + pp, p);
+            }
+        }
+    }
+
+# endregion

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
@@ -438,6 +438,14 @@ public class Class8<T, S>
                 return null;
             }
         }
+
+        public void LocalFunctionWithTypeConstraint<T>()
+        {            
+            T LocalFunction<T>() where T : Person
+            {
+            
+            }
+        }
     }
 
 #endregion
@@ -493,6 +501,38 @@ public class Class8<T, S>
             // named tuple elements in a literal
             return (first: first, middle: middle, last: last);
         }
+        
+        public void TupleTypesTest()
+        {
+            (int, double, DateTime) simpledeclaration;
+
+            (int, string) intitializedField = (2, "Two");
+
+            (int, string)[] tupleArray;
+
+            (int, string)[] tuppleArrayInitialized = { (1, "One"), (2, "Two") };
+
+            (double, string, DateTime)[] fixedSize = new (double, string, DateTime)[2];
+
+            (string name, DateTime age) namedTuple;
+            
+            List<(string, int)> listOfTuple = new List<(string, int)>();
+
+            List<(string name , int age)> listOfNamedTuple = new List<(string name , int age)>();
+
+            List<(string name, DateTime dob)> myList = new List<(string name, DateTime dob)>()
+                                                           {
+                                                               ("A", DateTime.Now)
+                                                           };
+
+            List<(string[] name, DateTime dob)> myList1 = new List<(string[] name, DateTime dob)>()
+                                                       {
+                                                           (new [] {"A", "B"}, DateTime.Now)
+                                                       };
+
+            List<(string name , int age?)> listOfNamedTupleNullable = new List<(string name , int age?)>();
+        }
+        
 
         // tuple return type
         (string, string, string) TupleTypeTest(long id)
@@ -519,6 +559,27 @@ public class Class8<T, S>
                 return (p + pp, p);
             }
         }
+
+        // Simple property
+        (decimal, string ) TupleTypeProperty { get; set; }
+
+        // Expression bodied property
+        (double, string) TupleTypePropertyWithExpression => (12.2, "Twelve Point Two");
+
+        // Property with accessor and expression body
+        (decimal, string) TupleProperty
+        {
+            get => TupleTypeProperty;
+
+            set => TupleTypeProperty = value;
+        }
+
+        // Indexer
+        public (decimal, string) this[int i]
+        {
+            get => TupleTypeProperty;
+            set => TupleTypeProperty = value;
+        }       
     }
 
 # endregion

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
@@ -530,7 +530,7 @@ public class Class8<T, S>
                                                            (new [] {"A", "B"}, DateTime.Now)
                                                        };
 
-            List<(string name , int age?)> listOfNamedTupleNullable = new List<(string name , int age?)>();
+            List<(string name , int? age)> listOfNamedTupleNullable = new List<(string name , int? age)>();
         }
         
 
@@ -573,6 +573,8 @@ public class Class8<T, S>
 
             set => TupleTypeProperty = value;
         }
+
+        public List<(IPEndPoint Source, IPEndPoint Destination)> ConnectionEndpoints { get; }
 
         // Indexer
         public (decimal, string) this[int i]

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
@@ -989,12 +989,12 @@
         </Statement>
         <Statement Type="VariableDeclarationStatement">
           <Expression Type="VariableDeclarationExpression">
-            <Expression Text="List&lt;(stringname,intage?)&gt;" Type="LiteralExpression" />
+            <Expression Text="List&lt;(stringname,int?age)&gt;" Type="LiteralExpression" />
             <Expression Type="VariableDeclaratorExpression">
               <Expression Text="listOfNamedTupleNullable" Type="LiteralExpression" />
               <Expression Type="NewExpression">
                 <Expression Type="MethodInvocationExpression">
-                  <Expression Text="List&lt;(stringname,intage?)&gt;" Type="LiteralExpression" />
+                  <Expression Text="List&lt;(stringname,int?age)&gt;" Type="LiteralExpression" />
                 </Expression>
               </Expression>
             </Expression>
@@ -1121,6 +1121,9 @@
             </Expression>
           </Statement>
         </Element>
+      </Element>
+      <Element Name="ConnectionEndpoints" Type="Property">
+        <Element Name="get" Type="Accessor" />
       </Element>
       <Element Name="this" Type="Indexer">
         <Element Name="get" Type="Accessor">

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
@@ -304,6 +304,89 @@
         </Statement>
       </Element>
     </Element>
+    <Element Name="Person" Type="Class">
+      <Element Name="names" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="ConcurrentDictionary&lt;int,string&gt;" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="names" Type="LiteralExpression" />
+              <Expression Type="NewExpression">
+                <Expression Type="MethodInvocationExpression">
+                  <Expression Text="ConcurrentDictionary&lt;int,string&gt;" Type="LiteralExpression" />
+                </Expression>
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="id" Type="Field">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="int" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="id" Type="LiteralExpression" />
+              <Expression Type="MethodInvocationExpression">
+                <Expression Text="GetId" Type="LiteralExpression" />
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="Person" Type="Constructor">
+        <Statement Type="ExpressionStatement">
+          <Expression Type="BodiedExpression">
+            <Expression Type="MethodInvocationExpression">
+              <Expression Type="MemberAccessExpression">
+                <Expression Text="names" Type="LiteralExpression" />
+                <Expression Text="TryAdd" Type="LiteralExpression" />
+              </Expression>
+              <Expression Text="id" Type="LiteralExpression" />
+              <Expression Text="name" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="~Person" Type="Destructor">
+        <Statement Type="ExpressionStatement">
+          <Expression Type="BodiedExpression">
+            <Expression Type="MethodInvocationExpression">
+              <Expression Type="MemberAccessExpression">
+                <Expression Text="names" Type="LiteralExpression" />
+                <Expression Text="TryRemove" Type="LiteralExpression" />
+              </Expression>
+              <Expression Text="id" Type="LiteralExpression" />
+              <Expression Text="_" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="Name" Type="Property">
+        <Element Name="get" Type="Accessor">
+          <Statement Type="ExpressionStatement">
+            <Expression Type="BodiedExpression">
+              <Expression Type="ArrayAccessExpression">
+                <Expression Text="names" Type="LiteralExpression" />
+                <Expression Text="id" Type="LiteralExpression" />
+              </Expression>
+            </Expression>
+          </Statement>
+        </Element>
+        <Element Name="set" Type="Accessor">
+          <Statement Type="ExpressionStatement">
+            <Expression Type="BodiedExpression">
+              <Expression Type="AssignmentExpression">
+                <Expression Type="ArrayAccessExpression">
+                  <Expression Text="names" Type="LiteralExpression" />
+                  <Expression Text="id" Type="LiteralExpression" />
+                </Expression>
+                <Expression Text="value" Type="LiteralExpression" />
+              </Expression>
+            </Expression>
+          </Statement>
+        </Element>
+      </Element>
+    </Element>
     <Element Name="RefReturnsAndLocals" Type="Class">
       <Element Name="Find" Type="Method">
         <Statement Type="ReturnStatement">
@@ -595,7 +678,50 @@
             </Statement>
           </Statement>
         </Statement>
-      </Element>    
+      </Element>
     </Element>
-  </Element>
+    <Element Name="OutVariables" Type="Class">
+      <Element Name="PrintCoordinates" Type="Method">
+        <Statement Type="ExpressionStatement">
+          <Expression Type="MethodInvocationExpression">
+            <Expression Type="MemberAccessExpression">
+              <Expression Text="p" Type="LiteralExpression" />
+              <Expression Text="GetCoordinates" Type="LiteralExpression" />
+            </Expression>
+            <Expression Text="int" Type="LiteralExpression" />
+            <Expression Text="x" Type="LiteralExpression" />
+            <Expression Text="int" Type="LiteralExpression" />
+            <Expression Text="y" Type="LiteralExpression" />
+          </Expression>
+        </Statement>
+        <Statement Type="ExpressionStatement">
+          <Expression Type="MethodInvocationExpression">
+            <Expression Type="MemberAccessExpression">
+              <Expression Text="p" Type="LiteralExpression" />
+              <Expression Text="GetCoordinates" Type="LiteralExpression" />
+            </Expression>
+            <Expression Text="var" Type="LiteralExpression" />
+            <Expression Text="x" Type="LiteralExpression" />
+            <Expression Text="_" Type="LiteralExpression" />
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="PrintStars" Type="Method">
+        <Statement Type="IfStatement">
+          <Expression Type="MethodInvocationExpression">
+            <Expression Type="MemberAccessExpression">
+              <Expression Text="int" Type="LiteralExpression" />
+              <Expression Text="TryParse" Type="LiteralExpression" />
+            </Expression>
+            <Expression Text="s" Type="LiteralExpression" />
+            <Expression Text="var" Type="LiteralExpression" />
+            <Expression Text="i" Type="LiteralExpression" />
+          </Expression>
+          <Statement Type="BlockStatement">
+            <Statement Type="ReturnStatement" />
+          </Statement>
+        </Statement>
+      </Element>
+    </Element>
+  </Element>    
 </StyleCopCsParserObjectModel>

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
@@ -723,5 +723,208 @@
         </Statement>
       </Element>
     </Element>
-  </Element>    
+    <Element Name="Tuples" Type="Class">
+      <Element Name="TuplesLiteralsTest" Type="Method">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="var" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="letters" Type="LiteralExpression" />
+              <Expression Type="TupleExpression">
+                <Expression Text="&quot;a&quot;" Type="LiteralExpression" />
+                <Expression Text="&quot;b&quot;" Type="LiteralExpression" />
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="var" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="alphabetStart" Type="LiteralExpression" />
+              <Expression Type="TupleExpression">
+                <Expression Text="&quot;a&quot;" Type="LiteralExpression" />
+                <Expression Text="&quot;b&quot;" Type="LiteralExpression" />
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="var" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="dateRange" Type="LiteralExpression" />
+              <Expression Type="TupleExpression">
+                <Expression Type="MemberAccessExpression">
+                  <Expression Text="DateTime" Type="LiteralExpression" />
+                  <Expression Text="MinValue" Type="LiteralExpression" />
+                </Expression>
+                <Expression Type="MemberAccessExpression">
+                  <Expression Text="DateTime" Type="LiteralExpression" />
+                  <Expression Text="MaxValue" Type="LiteralExpression" />
+                </Expression>
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="var" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="caculatedRange" Type="LiteralExpression" />
+              <Expression Type="TupleExpression">
+                <Expression Type="MethodInvocationExpression">
+                  <Expression Type="MemberAccessExpression">
+                    <Expression Text="dates" Type="LiteralExpression" />
+                    <Expression Text="First" Type="LiteralExpression" />
+                  </Expression>
+                </Expression>
+                <Expression Type="MethodInvocationExpression">
+                  <Expression Type="MemberAccessExpression">
+                    <Expression Text="dates" Type="LiteralExpression" />
+                    <Expression Text="Last" Type="LiteralExpression" />
+                  </Expression>
+                </Expression>
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="var" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="cast" Type="LiteralExpression" />
+              <Expression Type="TupleExpression">
+                <Expression Type="CastExpression">
+                  <Expression Text="string" Type="LiteralExpression" />
+                  <Expression Text="&quot;a&quot;" Type="LiteralExpression" />
+                </Expression>
+                <Expression Text="&quot;b&quot;" Type="LiteralExpression" />
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="var" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="nested" Type="LiteralExpression" />
+              <Expression Type="TupleExpression">
+                <Expression Type="TupleExpression">
+                  <Expression Text="&quot;a&quot;" Type="LiteralExpression" />
+                  <Expression Text="1" Type="LiteralExpression" />
+                </Expression>
+                <Expression Type="MemberAccessExpression">
+                  <Expression Text="DateTime" Type="LiteralExpression" />
+                  <Expression Text="Now" Type="LiteralExpression" />
+                </Expression>
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="ReturnStatement">
+          <Expression Type="TupleExpression">
+            <Expression Text="first" Type="LiteralExpression" />
+            <Expression Text="middle" Type="LiteralExpression" />
+            <Expression Text="last" Type="LiteralExpression" />
+          </Expression>
+        </Statement>
+        <Statement Type="ReturnStatement">
+          <Expression Type="TupleExpression">
+            <Expression Text="first" Type="LiteralExpression" />
+            <Expression Text="middle" Type="LiteralExpression" />
+            <Expression Text="last" Type="LiteralExpression" />
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="TupleTypeTest" Type="Method">
+        <Statement Type="ReturnStatement">
+          <Expression Type="TupleExpression">
+            <Expression Text="first" Type="LiteralExpression" />
+            <Expression Text="middle" Type="LiteralExpression" />
+            <Expression Text="last" Type="LiteralExpression" />
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="TupleTypeWithNameTest" Type="Method">
+        <Statement Type="ReturnStatement">
+          <Expression Type="TupleExpression">
+            <Expression Text="first" Type="LiteralExpression" />
+            <Expression Text="middle" Type="LiteralExpression" />
+            <Expression Text="last" Type="LiteralExpression" />
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="Fibonacci" Type="Method">
+        <Statement Type="IfStatement">
+          <Expression Type="RelationalExpression">
+            <Expression Text="x" Type="LiteralExpression" />
+            <Expression Text="0" Type="LiteralExpression" />
+          </Expression>
+          <Statement Type="ThrowStatement">
+            <Expression Type="NewExpression">
+              <Expression Type="MethodInvocationExpression">
+                <Expression Text="ArgumentException" Type="LiteralExpression" />
+                <Expression Text="&quot;Less negativity please!&quot;" Type="LiteralExpression" />
+                <Expression Type="NameofExpression">
+                  <Expression Text="x" Type="LiteralExpression" />
+                </Expression>
+              </Expression>
+            </Expression>
+          </Statement>
+        </Statement>
+        <Statement Type="ReturnStatement">
+          <Expression Type="MemberAccessExpression">
+            <Expression Type="MethodInvocationExpression">
+              <Expression Text="Fib" Type="LiteralExpression" />
+              <Expression Text="x" Type="LiteralExpression" />
+            </Expression>
+            <Expression Text="current" Type="LiteralExpression" />
+          </Expression>
+        </Statement>
+        <Statement Type="LocalFunctionStatement">
+          <Expression Text="Fib" Type="LiteralExpression" />
+          <Statement Type="BlockStatement">
+            <Statement Type="IfStatement">
+              <Expression Type="RelationalExpression">
+                <Expression Text="i" Type="LiteralExpression" />
+                <Expression Text="0" Type="LiteralExpression" />
+              </Expression>
+              <Statement Type="ReturnStatement">
+                <Expression Type="TupleExpression">
+                  <Expression Text="1" Type="LiteralExpression" />
+                  <Expression Text="0" Type="LiteralExpression" />
+                </Expression>
+              </Statement>
+            </Statement>
+            <Statement Type="ExpressionStatement">
+              <Expression Type="AssignmentExpression">
+                <Expression Type="MethodInvocationExpression">
+                  <Expression Text="var" Type="LiteralExpression" />
+                  <Expression Text="p" Type="LiteralExpression" />
+                  <Expression Text="pp" Type="LiteralExpression" />
+                </Expression>
+                <Expression Type="MethodInvocationExpression">
+                  <Expression Text="Fib" Type="LiteralExpression" />
+                  <Expression Type="ArithmeticExpression">
+                    <Expression Text="i" Type="LiteralExpression" />
+                    <Expression Text="1" Type="LiteralExpression" />
+                  </Expression>
+                </Expression>
+              </Expression>
+            </Statement>
+            <Statement Type="ReturnStatement">
+              <Expression Type="TupleExpression">
+                <Expression Type="ArithmeticExpression">
+                  <Expression Text="p" Type="LiteralExpression" />
+                  <Expression Text="pp" Type="LiteralExpression" />
+                </Expression>
+                <Expression Text="p" Type="LiteralExpression" />
+              </Expression>
+            </Statement>
+          </Statement>
+        </Statement>
+      </Element>
+    </Element>
+  </Element>
 </StyleCopCsParserObjectModel>

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
@@ -679,6 +679,12 @@
           </Statement>
         </Statement>
       </Element>
+      <Element Name="LocalFunctionWithTypeConstraint&lt;T&gt;" Type="Method">
+        <Statement Type="LocalFunctionStatement">
+          <Expression Text="LocalFunction&lt;T&gt;" Type="LiteralExpression" />
+          <Statement Type="BlockStatement" />
+        </Statement>
+      </Element>
     </Element>
     <Element Name="OutVariables" Type="Class">
       <Element Name="PrintCoordinates" Type="Method">
@@ -837,6 +843,164 @@
           </Expression>
         </Statement>
       </Element>
+      <Element Name="TupleTypesTest" Type="Method">
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(int,double,DateTime)" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="simpledeclaration" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(int,string)" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="intitializedField" Type="LiteralExpression" />
+              <Expression Type="TupleExpression">
+                <Expression Text="2" Type="LiteralExpression" />
+                <Expression Text="&quot;Two&quot;" Type="LiteralExpression" />
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(int,string)[]" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tupleArray" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(int,string)[]" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="tuppleArrayInitialized" Type="LiteralExpression" />
+              <Expression Type="ArrayInitializerExpression">
+                <Expression Type="TupleExpression">
+                  <Expression Text="1" Type="LiteralExpression" />
+                  <Expression Text="&quot;One&quot;" Type="LiteralExpression" />
+                </Expression>
+                <Expression Type="TupleExpression">
+                  <Expression Text="2" Type="LiteralExpression" />
+                  <Expression Text="&quot;Two&quot;" Type="LiteralExpression" />
+                </Expression>
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(double,string,DateTime)[]" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="fixedSize" Type="LiteralExpression" />
+              <Expression Type="NewArrayExpression">
+                <Expression Type="ArrayAccessExpression">
+                  <Expression Text="(double,string,DateTime)" Type="LiteralExpression" />
+                  <Expression Text="2" Type="LiteralExpression" />
+                </Expression>
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="(stringname,DateTimeage)" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="namedTuple" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="List&lt;(string,int)&gt;" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="listOfTuple" Type="LiteralExpression" />
+              <Expression Type="NewExpression">
+                <Expression Type="MethodInvocationExpression">
+                  <Expression Text="List&lt;(string,int)&gt;" Type="LiteralExpression" />
+                </Expression>
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="List&lt;(stringname,intage)&gt;" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="listOfNamedTuple" Type="LiteralExpression" />
+              <Expression Type="NewExpression">
+                <Expression Type="MethodInvocationExpression">
+                  <Expression Text="List&lt;(stringname,intage)&gt;" Type="LiteralExpression" />
+                </Expression>
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="List&lt;(stringname,DateTimedob)&gt;" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="myList" Type="LiteralExpression" />
+              <Expression Type="NewExpression">
+                <Expression Type="MethodInvocationExpression">
+                  <Expression Text="List&lt;(stringname,DateTimedob)&gt;" Type="LiteralExpression" />
+                </Expression>
+                <Expression Type="CollectionInitializerExpression">
+                  <Expression Type="TupleExpression">
+                    <Expression Text="&quot;A&quot;" Type="LiteralExpression" />
+                    <Expression Type="MemberAccessExpression">
+                      <Expression Text="DateTime" Type="LiteralExpression" />
+                      <Expression Text="Now" Type="LiteralExpression" />
+                    </Expression>
+                  </Expression>
+                </Expression>
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="List&lt;(string[]name,DateTimedob)&gt;" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="myList1" Type="LiteralExpression" />
+              <Expression Type="NewExpression">
+                <Expression Type="MethodInvocationExpression">
+                  <Expression Text="List&lt;(string[]name,DateTimedob)&gt;" Type="LiteralExpression" />
+                </Expression>
+                <Expression Type="CollectionInitializerExpression">
+                  <Expression Type="TupleExpression">
+                    <Expression Type="NewArrayExpression">
+                      <Expression Type="ArrayInitializerExpression">
+                        <Expression Text="&quot;A&quot;" Type="LiteralExpression" />
+                        <Expression Text="&quot;B&quot;" Type="LiteralExpression" />
+                      </Expression>
+                    </Expression>
+                    <Expression Type="MemberAccessExpression">
+                      <Expression Text="DateTime" Type="LiteralExpression" />
+                      <Expression Text="Now" Type="LiteralExpression" />
+                    </Expression>
+                  </Expression>
+                </Expression>
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+        <Statement Type="VariableDeclarationStatement">
+          <Expression Type="VariableDeclarationExpression">
+            <Expression Text="List&lt;(stringname,intage?)&gt;" Type="LiteralExpression" />
+            <Expression Type="VariableDeclaratorExpression">
+              <Expression Text="listOfNamedTupleNullable" Type="LiteralExpression" />
+              <Expression Type="NewExpression">
+                <Expression Type="MethodInvocationExpression">
+                  <Expression Text="List&lt;(stringname,intage?)&gt;" Type="LiteralExpression" />
+                </Expression>
+              </Expression>
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
       <Element Name="TupleTypeTest" Type="Method">
         <Statement Type="ReturnStatement">
           <Expression Type="TupleExpression">
@@ -924,6 +1088,58 @@
             </Statement>
           </Statement>
         </Statement>
+      </Element>
+      <Element Name="TupleTypeProperty" Type="Property">
+        <Element Name="get" Type="Accessor" />
+        <Element Name="set" Type="Accessor" />
+      </Element>
+      <Element Name="TupleTypePropertyWithExpression" Type="Property">
+        <Statement Type="ExpressionStatement">
+          <Expression Type="BodiedExpression">
+            <Expression Type="TupleExpression">
+              <Expression Text="12.2" Type="LiteralExpression" />
+              <Expression Text="&quot;Twelve Point Two&quot;" Type="LiteralExpression" />
+            </Expression>
+          </Expression>
+        </Statement>
+      </Element>
+      <Element Name="TupleProperty" Type="Property">
+        <Element Name="get" Type="Accessor">
+          <Statement Type="ExpressionStatement">
+            <Expression Type="BodiedExpression">
+              <Expression Text="TupleTypeProperty" Type="LiteralExpression" />
+            </Expression>
+          </Statement>
+        </Element>
+        <Element Name="set" Type="Accessor">
+          <Statement Type="ExpressionStatement">
+            <Expression Type="BodiedExpression">
+              <Expression Type="AssignmentExpression">
+                <Expression Text="TupleTypeProperty" Type="LiteralExpression" />
+                <Expression Text="value" Type="LiteralExpression" />
+              </Expression>
+            </Expression>
+          </Statement>
+        </Element>
+      </Element>
+      <Element Name="this" Type="Indexer">
+        <Element Name="get" Type="Accessor">
+          <Statement Type="ExpressionStatement">
+            <Expression Type="BodiedExpression">
+              <Expression Text="TupleTypeProperty" Type="LiteralExpression" />
+            </Expression>
+          </Statement>
+        </Element>
+        <Element Name="set" Type="Accessor">
+          <Statement Type="ExpressionStatement">
+            <Expression Type="BodiedExpression">
+              <Expression Type="AssignmentExpression">
+                <Expression Text="TupleTypeProperty" Type="LiteralExpression" />
+                <Expression Text="value" Type="LiteralExpression" />
+              </Expression>
+            </Expression>
+          </Statement>
+        </Element>
       </Element>
     </Element>
   </Element>


### PR DESCRIPTION
- Parser support for Tuple types and literals
- Parser support for type constraints on local functions
- Related unit tests
- Change type of ParentElement property of TypeParameterConstraintClause to CodeUnit as statements can now have type constraints