### PR TITLE
Fix bugs

### DIFF
--- a/Project/Src/StyleCop.CSharp.Rules/LayoutRules.cs
+++ b/Project/Src/StyleCop.CSharp.Rules/LayoutRules.cs
@@ -596,8 +596,14 @@ namespace StyleCop.CSharp
                 }
                 else if (element.ElementType == ElementType.Property)
                 {
-                    // Automatic properties are allowed to be on a single line, but normal properties are not.
-                    this.CheckElementBracketPlacement(element, IsAutomaticProperty((Property)element));
+                    Property itemBeingInspected = (Property)element;
+
+                    // Automatic/Expression bodied properties are allowed to be on a single line, but normal properties are not.
+                    bool allowAllOnOneLine = IsAutomaticProperty(itemBeingInspected) ||
+                        (itemBeingInspected.ChildStatements.Count == 1 &&
+                         itemBeingInspected.ChildStatements.First() is ExpressionStatement);
+
+                    this.CheckElementBracketPlacement(element, allowAllOnOneLine);
                 }
             }
         }

--- a/Project/Src/StyleCop.CSharp/Statements/CatchStatement.cs
+++ b/Project/Src/StyleCop.CSharp/Statements/CatchStatement.cs
@@ -106,6 +106,11 @@ namespace StyleCop.CSharp
                 }
             }
 
+            if (whenStatement != null)
+            {
+                this.AddStatement(whenStatement);
+            }
+
             this.AddStatement(embeddedStatement);
         }
 

--- a/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/CurlyBrackets/CurlyBracketsProperties.cs
+++ b/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/CurlyBrackets/CurlyBracketsProperties.cs
@@ -153,5 +153,7 @@ namespace CSharpAnalyzersTest.TestData
 
         public bool ValidProperty10 { get; } =
             GetPropertyValue();
+
+        public int[] ValidProperty11 => new int[] { };
     }
 }

--- a/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Documentation/DocumentationMethods.cs
+++ b/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Documentation/DocumentationMethods.cs
@@ -597,5 +597,31 @@ namespace CSharpAnalyzersTest.TestData
             {
             }
         }
+
+        /// <summary>
+        /// While this test case is not for documentation rules, we use this
+        /// to verify the bug where multiline interpolated string results in incorrect line numbers.
+        /// </summary>
+        private static void TestCaseForIssue105Part1()
+        {
+            int value;
+            var singleLineDummyString = $@"Some Text";
+
+            // Declare dummy string.
+            var dummyString = string.Format(
+                $@"
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean 
+commodo ligula eget dolor. Aenean massa. Cum sociis natoque {0} 
+penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+",
+                value);
+
+            // Do something with the dummy string.
+            TransferQueue.Enqueue(dummyString);
+        }
+
+        private static void TestCaseForIssue105Part2()
+        {
+        }
     }
 }

--- a/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Documentation/TestDescription.xml
+++ b/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Documentation/TestDescription.xml
@@ -606,6 +606,7 @@
       <Violation Section="Root.CSharpAnalyzersTest.TestData.DocumentationMethods.SA1601TestCode.MethodName" LineNumber="591" Rule="PartialElementsMustBeDocumented" />
       <Violation Section="Root.CSharpAnalyzersTest.TestData.DocumentationMethods.SA1601TestCode" LineNumber="594" Rule="PartialElementsMustBeDocumented" />
       <Violation Section="Root.CSharpAnalyzersTest.TestData.DocumentationMethods.SA1601TestCode.MethodName" LineNumber="596" Rule="PartialElementsMustBeDocumented" />
+      <Violation Section="Root.CSharpAnalyzersTest.TestData.DocumentationMethods.TestCaseForIssue105Part2" LineNumber="623" RuleNamespace="StyleCop.CSharp.DocumentationRules" Rule="ElementsMustBeDocumented" />
       <Violation Section="Root.CSharpAnalyzersTest.TestData.DocumentationProperties.InvalidProperty1" LineNumber="130" Rule="ElementDocumentationMustNotHaveDefaultSummary" />
       <Violation Section="Root.CSharpAnalyzersTest.TestData.DocumentationProperties.InvalidProperty1" LineNumber="130" Rule="PropertySummaryDocumentationMustMatchAccessors" />
       <Violation Section="Root.CSharpAnalyzersTest.TestData.DocumentationProperties.InvalidProperty2" LineNumber="138" Rule="DocumentationMustContainValidXml" />

--- a/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Spacing/OpenParenthesis.cs
+++ b/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Spacing/OpenParenthesis.cs
@@ -34,5 +34,20 @@ namespace CSharpAnalyzersTest.TestData.Spacing
                     orderby g.Key ascending
                     select new NameCount { Name = g.Key.ToString(), Count = g.Count() };
         }
-   }
+
+        public void TestForIssue133()
+        {
+            try
+            {
+                int i;
+            }
+            catch (Exception e) when
+            (
+                e is SomeException ||
+                e is SomeOtherException
+            )
+            {
+            }
+        }
+    }
 }

--- a/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Spacing/TestDescription.xml
+++ b/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Spacing/TestDescription.xml
@@ -285,6 +285,12 @@
       <Violation Section="Root.CloseParenthesisSpacing.Class21.Test`T%T"
                  LineNumber="144"
                  Rule="ClosingParenthesisMustBeSpacedCorrectly" />
+      <Violation Section="Root.CSharpAnalyzersTest.TestData.Spacing.OpenParenthesis.TestForIssue133" 
+                 LineNumber="45" 
+                 Rule="OpeningParenthesisMustBeSpacedCorrectly" />
+      <Violation Section="Root.CSharpAnalyzersTest.TestData.Spacing.OpenParenthesis.TestForIssue133" 
+                 LineNumber="48" 
+                 Rule="ClosingParenthesisMustBeSpacedCorrectly" />
     </ExpectedViolations>
   </Test>
   <Test Name="CloseCurlyBracket">

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/FilterExceptionsObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/FilterExceptionsObjectModel.xml
@@ -17,6 +17,9 @@
         </Statement>
         <Statement Type="CatchStatement">
           <Expression Text="Exception" Type="LiteralExpression" />
+          <Statement Type="WhenStatement">
+            <Expression Text="true" Type="LiteralExpression" />
+          </Statement>
           <Statement Type="BlockStatement" />
         </Statement>
       </Element>


### PR DESCRIPTION
- Fix bug in catch statement, where 'when' clause is not included into the hierarchy
- Fix bug where SA1502 is reported for expression bodied properties with object/collection initializers
- Fix bug when parsing multiline Verbatim interpolated strings, where line numbers are not incremented.