### PR TITLE
Fix https://github.com/StyleCop/StyleCop/issues/160

### DIFF
--- a/Project/Src/StyleCop/Spelling/SpellChecker.cs
+++ b/Project/Src/StyleCop/Spelling/SpellChecker.cs
@@ -578,7 +578,7 @@ namespace StyleCop.Spelling
                     }
 
                     proofDirectories.Add(AppDomain.CurrentDomain.BaseDirectory);
-                    proofDirectories.Add(Assembly.GetExecutingAssembly().Location);
+                    proofDirectories.Add(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
 
                     pathsToOfficeProofingTools = proofDirectories.ToArray();
 


### PR DESCRIPTION
Problem: 
The stylecop speller (SA1650) doesn't work on 64-bit Windows-OS (if 32-bit Office isn't installed)

Reasons: 
(1) stylecop-task code checks 32bit registry location. 
(2) stylecop-task fails to fallback to it's own speller.

Fix: 
Make fallback work (i.e. fix path to mssp7en.dll).

Additional Fix (though not implemented in this change): 
Check both 32bit and 64bit registry location.