### PR TITLE
Fix: Support of C#7 tuples in methods

### DIFF
--- a/Project/Src/StyleCop.CSharp.Rules/SpacingRules.cs
+++ b/Project/Src/StyleCop.CSharp.Rules/SpacingRules.cs
@@ -79,7 +79,7 @@ namespace StyleCop.CSharp
             CsTokenType type = token.CsTokenType;
 
             if (type == CsTokenType.CloseParenthesis || type == CsTokenType.OpenParenthesis || type == CsTokenType.CloseSquareBracket
-                || type == CsTokenType.OpenSquareBracket || type == CsTokenType.CloseAttributeBracket || type == CsTokenType.Semicolon || type == CsTokenType.Comma)
+                || type == CsTokenType.OpenSquareBracket || type == CsTokenType.CloseAttributeBracket || type == CsTokenType.Semicolon || type == CsTokenType.Comma || type == CsTokenType.CloseGenericBracket)
             {
                 return true;
             }


### PR DESCRIPTION
Adding the closing generic brackets seems to solve the problem with the spacing rules also adressed in ticket #179.