### PR TITLE
Fix various bugs

### DIFF
--- a/Project/Src/StyleCop.CSharp.Rules/SpacingRules.cs
+++ b/Project/Src/StyleCop.CSharp.Rules/SpacingRules.cs
@@ -255,9 +255,10 @@ namespace StyleCop.CSharp
                 CsTokenType nextType = nextNode.Value.CsTokenType;
                 CsTokenType nextNextType = nextNode.Next == null ? CsTokenType.Other : nextNode.Next.Value.CsTokenType;
 
-                if (tokenNode.Value.Parent is CastExpression)
+                if (tokenNode.Value.Parent is CastExpression || tokenNode.Value.Parent is GenericType)
                 {
-                    // There should not be any whitespace after the closing parenthesis in a cast expression.
+                    // There should not be any whitespace after the closing parenthesis in a CastExpression.
+                    // There should not be any whitspace after tuple type declaration in a GenericType
                     if (nextType == CsTokenType.WhiteSpace)
                     {
                         this.AddViolation(tokenNode.Value.FindParentElement(), nextNode.Value.Location, Rules.ClosingParenthesisMustBeSpacedCorrectly);
@@ -989,7 +990,7 @@ namespace StyleCop.CSharp
                             || ////itemType == CsTokenType.SingleLineComment ||
                             itemType == CsTokenType.Switch || itemType == CsTokenType.Throw || itemType == CsTokenType.Using || itemType == CsTokenType.Where
                             || itemType == CsTokenType.While || itemType == CsTokenType.WhileDo || itemType == CsTokenType.Yield || itemType == CsTokenType.LabelColon
-                            || itemType == CsTokenType.Async || itemType == CsTokenType.By || itemType == CsTokenType.When)
+                            || itemType == CsTokenType.Async || itemType == CsTokenType.By || itemType == CsTokenType.When || item.Text == "var")
                         {
                             break;
                         }

--- a/Project/Src/StyleCop.CSharp/CodeLexer.cs
+++ b/Project/Src/StyleCop.CSharp/CodeLexer.cs
@@ -2555,7 +2555,7 @@ namespace StyleCop.CSharp
             if (isVerbatim)
             {
                 char verbatimChar = this.codeReader.ReadNext();
-                Debug.Assert(verbatimChar == '@' , "Expected a verbatim character");
+                Debug.Assert(verbatimChar == '@', "Expected a verbatim character");
                 text.Append(verbatimChar);
             }
 

--- a/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
@@ -1969,9 +1969,18 @@ namespace StyleCop.CSharp
                     rightHandSide = this.GetTypeTokenExpression(expressionReference, unsafeCode, true, true);
 
                     // Check if we have a variable declared as part of pattern match.
-                    nextSymbol = this.PeekNextSymbol(SkipSymbols.All, false);
+                    // Next symbol must be other, and the following symbol must be ')', ';' or start of another operator).
+                    int foundPosition;
+                    OperatorCategory operatorCategory;
+                    OperatorType operatorType;
 
-                    if (nextSymbol.SymbolType == SymbolType.Other)
+                    nextSymbol = this.PeekNextSymbolFrom(0, SkipSymbols.All, false, out foundPosition);
+                    Symbol followingSymbol = this.PeekNextSymbolFrom(foundPosition, SkipSymbols.All, false, out foundPosition);
+
+                    if (nextSymbol.SymbolType == SymbolType.Other &&
+                        (followingSymbol.SymbolType == SymbolType.CloseParenthesis
+                        || followingSymbol.SymbolType == SymbolType.Semicolon
+                        || GetOperatorType(followingSymbol, out operatorType, out operatorCategory)))
                     {
                         matchVariable = this.GetNextExpression(ExpressionPrecedence.Primary, parentReference, unsafeCode);
                     }

--- a/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
@@ -2767,7 +2767,7 @@ namespace StyleCop.CSharp
                         }
                         else if (symbol.Text == "var" && DetectTupleType(0) > 0)
                         {
-                            expression = this.GetDeconstuctionTupleExpression(unsafeCode, true);
+                            expression = this.GetTupleTypeDeclarationExpression(unsafeCode, true);
                         }
 
                         // If the expression is still null now, this is just a regular 'other' expression.
@@ -2848,10 +2848,6 @@ namespace StyleCop.CSharp
                         if (this.IsLambdaExpression())
                         {
                             expression = this.GetLambdaExpression(parentReference, unsafeCode);
-                        }
-                        else if (this.IsDeconstructionExpression())
-                        {
-                            expression = this.GetDeconstuctionTupleExpression(unsafeCode, false);
                         }
                         else
                         {
@@ -3393,13 +3389,14 @@ namespace StyleCop.CSharp
             }
             else
             {
-                Argument firstArgument = null;
+                // We are parsing a Tuple variable or declaration.
+                List<Argument> tupleArguments = null;
+                List<VariableDeclarationExpression> tupleVariables = null;
 
-                // We are parsing a Tuple literal.
                 if (nextSymbol.SymbolType == SymbolType.Comma)
                 {
                     // We already read the expression, just create an Argument out it.
-                    firstArgument = new Argument(
+                    var firstArgument = new Argument(
                         null,
                         ParameterModifiers.None,
                         firstExpression,
@@ -3408,32 +3405,25 @@ namespace StyleCop.CSharp
                         firstExpression.Tokens,
                         this.symbols.Generated);
                     this.tokens.Add(this.GetToken(CsTokenType.Comma, SymbolType.Comma, expressionReference));
+                    tupleArguments = this.ReadRemainingTupleArguments(expressionReference, firstArgument, unsafeCode);
                 }
-                else if (nextSymbol.SymbolType == SymbolType.Colon 
-                    && firstExpression.Tokens.First == firstExpression.Tokens.Last)
+                else if ((nextSymbol.SymbolType == SymbolType.Colon) && firstExpression.Tokens.First == firstExpression.Tokens.Last)
                 {
-                    // This is a named Argument and we partially read it, discard the firstExpression and read the Argument.
-                    firstArgument = this.GetNextArgument(
+                    // This is a named Argument or type declaration in tuple, and we partially read it, discard the firstExpression and read the Argument.
+                    var firstArgument = this.GetNextArgument(
                         expressionReference,
                         unsafeCode,
                         this.symbols.Current,
                         true,
                         this.tokens.Last.Previous);
+                    tupleArguments = this.ReadRemainingTupleArguments(expressionReference, firstArgument, unsafeCode);
+                }
+                else if (nextSymbol.SymbolType == SymbolType.Other && firstExpression.Tokens.First == firstExpression.Tokens.Last)
+                {
+                    // We are in tuple type declaration.
+                    tupleVariables = this.ReadRemainingTupleVariables(expressionReference, firstExpression, unsafeCode);
                 }
                 else
-                {
-                    this.CreateSyntaxException();                
-                }
-
-                // Get the remaining list of arguments.
-                IList<Argument> argumentsList = this.GetArgumentList(SymbolType.CloseParenthesis, expressionReference, unsafeCode);
-
-                // Prepare a new list that includes our first argument.
-                List<Argument> tupleLiteralArguments = new List<Argument> { firstArgument };
-                tupleLiteralArguments.AddRange(argumentsList);
-
-                // Should have more than one argument.
-                if (tupleLiteralArguments.Count == 1)
                 {
                     this.CreateSyntaxException();
                 }
@@ -3446,7 +3436,14 @@ namespace StyleCop.CSharp
                 partialTokens = new CsTokenList(this.tokens, openParenthesisNode, this.tokens.Last);
 
                 // Create the expression.
-                resultExpression = new TupleExpression(partialTokens, tupleLiteralArguments.ToArray());                
+                if (tupleArguments != null)
+                {
+                    resultExpression = new TupleExpression(partialTokens, tupleArguments.ToArray());
+                }
+                else
+                {
+                    resultExpression = new TupleExpression(partialTokens, tupleVariables);
+                }
             }
 
             // Link the opening and closing parenthesis and return the expression.
@@ -3457,8 +3454,61 @@ namespace StyleCop.CSharp
             return resultExpression;
         }
 
+        private List<Argument> ReadRemainingTupleArguments(Reference<ICodePart> expressionReference, Argument firstArgument, bool unsafeCode)
+        {
+            // Get the remaining list of arguments.
+            IList<Argument> argumentsList = this.GetArgumentList(SymbolType.CloseParenthesis, expressionReference, unsafeCode);
+
+            // Prepare a new list that includes our first argument.
+            List<Argument> tupleLiteralArguments = new List<Argument> { firstArgument };
+            tupleLiteralArguments.AddRange(argumentsList);
+
+            // Should have more than one argument.
+            if (tupleLiteralArguments.Count == 1)
+            {
+                this.CreateSyntaxException();
+            }
+
+            return tupleLiteralArguments;
+        }
+
+        private List<VariableDeclarationExpression> ReadRemainingTupleVariables(Reference<ICodePart> expressionReference, Expression firstVariableType, bool unsafeCode)
+        {
+            List<VariableDeclarationExpression> result = new List<VariableDeclarationExpression>();
+            
+            // Add the first variable
+            result.Add(this.GetSingleVariableDeclarationExpression(firstVariableType, ExpressionPrecedence.None, unsafeCode));
+
+            // Read the comma.
+            Symbol symbol = this.GetNextSymbol(SkipSymbols.All, expressionReference, false);
+            this.tokens.Add(this.GetToken(CsTokenType.Comma, SymbolType.Comma, expressionReference));
+
+            while (symbol.SymbolType != SymbolType.CloseParenthesis)
+            {
+                Expression variableType;
+
+                // Get the variable type and declaration.
+                variableType = this.GetNextExpression(ExpressionPrecedence.None, expressionReference, unsafeCode);
+                result.Add(this.GetSingleVariableDeclarationExpression(variableType, ExpressionPrecedence.None, unsafeCode));
+
+                // Now check if the next character is a comma. If so there is another variable declared.
+                symbol = this.GetNextSymbol(SkipSymbols.All, expressionReference, false);
+
+                // Break if there are no more declarations.
+                if (symbol.SymbolType != SymbolType.Comma)
+                {
+                    break;
+                }
+
+                // Add the comma and continue reading the next declaration.
+                this.tokens.Add(this.GetToken(CsTokenType.Comma, SymbolType.Comma, expressionReference));
+            }
+
+            return result;
+        }
+
         /// <summary>
-        /// Reads deconstruction tuple expression.
+        /// Reads tuple type expression.
         /// </summary>
         /// <param name="unsafeCode">
         /// Indicates whether the code being parsed resides in an unsafe code block.
@@ -3467,7 +3517,7 @@ namespace StyleCop.CSharp
         /// <returns>
         /// Returns a TupleExpression or ParenthesizedExpression.
         /// </returns>
-        private TupleExpression GetDeconstuctionTupleExpression(bool unsafeCode, bool isVar)
+        private TupleExpression GetTupleTypeDeclarationExpression(bool unsafeCode, bool isVar)
         {
             //// Note: What we do here is slightly different from roslyn syntax tree.
             //// (string fname, string lname) = person is read as, TupleExpression with arguments that are declaration expressions
@@ -5509,19 +5559,6 @@ namespace StyleCop.CSharp
             }
 
             return dereference;
-        }
-
-        /// <summary>
-        /// Determines whether the next expression is a deconstruction expression.
-        /// </summary>
-        /// <returns>Returns true if the next expression is a lambda expression.</returns>
-        private bool IsDeconstructionExpression()
-        {
-            int foundPosition = this.DetectTupleType(0);
-
-            return foundPosition > 0 
-                && this.PeekNextSymbolFrom(foundPosition, SkipSymbols.All, false, out foundPosition).SymbolType 
-                    == SymbolType.Equals;
         }
 
         /// <summary>

--- a/Project/Src/StyleCop.CSharp/CodeParser.Statements.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Statements.cs
@@ -577,7 +577,7 @@ namespace StyleCop.CSharp
 
             // If ref, then move past 'ref'/'await' + white space which would be the type declaration.
             // Othwerwise, the next symbol would be the type declaration.
-            bool isAsyncKeyword = (currentSymbol.SymbolType == SymbolType.Other && currentSymbol.Text == "async");
+            bool isAsyncKeyword = currentSymbol.SymbolType == SymbolType.Other && currentSymbol.Text == "async";
             int testPosition = currentSymbol.SymbolType == SymbolType.Ref || isAsyncKeyword ? 3  : 1;
 
             int angleBracketCount = 0;
@@ -638,8 +638,15 @@ namespace StyleCop.CSharp
                     continue;
                 }
 
-                // We are at the right place, evaluate our expectation that next symbol is open paranthesis, or <.
                 Symbol nextSymbol = this.PeekNextSymbolFrom(testPosition, SkipSymbols.WhiteSpace, false, out testPosition);
+
+                // If we are '.' or the next symbol is a '.' , then we could be in a namespace of fully qualified return type.
+                if (symbol.SymbolType == SymbolType.Dot || nextSymbol.SymbolType == SymbolType.Dot)
+                {
+                    continue;
+                }
+
+                // We are at the right place, evaluate our expectation that next symbol is open paranthesis, or <.
                 return symbol.SymbolType == SymbolType.Other
                     && (nextSymbol.SymbolType == SymbolType.OpenParenthesis || nextSymbol.SymbolType == SymbolType.LessThan);
             }

--- a/Project/Src/StyleCop.CSharp/CodeParser.Statements.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Statements.cs
@@ -2025,24 +2025,28 @@ namespace StyleCop.CSharp
 
             Expression identifier = this.GetNextExpression(ExpressionPrecedence.None, statementReference, unsafeCode);
 
+            // The next symbol could be a vairable definition, the when keyword, a variable definition followed by when keyword, or a ':'
             // Get the variable definition as part of pattern match, if available.
             Expression matchVariable = null;
+            Expression whenExpression = null;
             Symbol nextSymbol = this.PeekNextSymbol(SkipSymbols.All, unsafeCode);
 
             if (nextSymbol.SymbolType == SymbolType.Other)
             {
-                this.GetNextSymbol(SkipSymbols.All, statementReference, false);
-                matchVariable = this.GetNextExpression(ExpressionPrecedence.Primary, statementReference, unsafeCode);
-            }
+                // If next symbol is not 'when', then it's a variable declartion, read it and rest nextSymbol to the following one.
+                if (nextSymbol.Text != "when")
+                {
+                    this.GetNextSymbol(SkipSymbols.All, statementReference, false);
+                    matchVariable = this.GetNextExpression(ExpressionPrecedence.Primary, statementReference, unsafeCode);
+                    nextSymbol = this.PeekNextSymbol(SkipSymbols.All, unsafeCode);
+                }
 
-            // Get the when expression, if available.
-            Expression whenExpression = null;
-            nextSymbol = this.PeekNextSymbol(SkipSymbols.All, unsafeCode);
-
-            if (nextSymbol.SymbolType == SymbolType.Other && nextSymbol.Text == "when")
-            {
-                this.tokens.Add(this.GetToken(CsTokenType.Other, SymbolType.Other, statementReference));
-                whenExpression = this.GetNextExpression(ExpressionPrecedence.None, statementReference, unsafeCode);
+                // Either a variable was not found, or was found and we moved to the next symbol. Check if this is a 'when' symbol.
+                if (nextSymbol.SymbolType == SymbolType.Other && nextSymbol.Text == "when")
+                {
+                    this.tokens.Add(this.GetToken(CsTokenType.Other, SymbolType.Other, statementReference));
+                    whenExpression = this.GetNextExpression(ExpressionPrecedence.None, statementReference, unsafeCode);
+                }
             }
 
             // Get the colon.

--- a/Project/Src/StyleCop.CSharp/CodeParser.Symbols.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Symbols.cs
@@ -731,7 +731,7 @@ namespace StyleCop.CSharp
 
             if (nextSymbol.SymbolType == SymbolType.OpenParenthesis)
             {
-                token = this.GetTupleTypeToken(typeTokenReference, parentReference, includeArrayBrackets);
+                token = this.GetTupleTypeToken(typeTokenReference, parentReference, includeArrayBrackets, isExpression);
             }
             else if (nextSymbol.SymbolType == SymbolType.Other)
             {
@@ -1181,7 +1181,7 @@ namespace StyleCop.CSharp
         /// Indicates whether to include array brackets in the type token.
         /// </param>
         /// <returns>A TypeToken representing the Tuple type.</returns>
-        private TypeToken GetTupleTypeToken(Reference<ICodePart> typeTokenReference, Reference<ICodePart> parentReference, bool includeArrayBrackets)
+        private TypeToken GetTupleTypeToken(Reference<ICodePart> typeTokenReference, Reference<ICodePart> parentReference, bool includeArrayBrackets, bool isExpression)
         {
             Param.AssertNotNull(typeTokenReference, nameof(typeTokenReference));
             Param.AssertNotNull(parentReference, nameof(parentReference));
@@ -1256,10 +1256,13 @@ namespace StyleCop.CSharp
                 }
             }
 
+            int startPosition = 1;
+
+            this.GetTypeTokenNullableTypeSymbol(typeTokenReference, typeTokens, isExpression, ref startPosition);
+
             if (includeArrayBrackets)
             {
                 // Read any array brackets and advance to the position of the last token read.
-                int startPosition = 1;
                 this.GetTypeTokenArrayBrackets(typeTokenReference, typeTokens, ref startPosition);
                 this.symbols.CurrentIndex += startPosition - 1;
             }

--- a/Project/Src/StyleCop.CSharp/Statements/ForeachStatement.cs
+++ b/Project/Src/StyleCop.CSharp/Statements/ForeachStatement.cs
@@ -31,9 +31,9 @@ namespace StyleCop.CSharp
         private readonly Expression item;
 
         /// <summary>
-        /// The variable declared in the foreach statement declaration.
+        /// The variable or tuple type, declared in the foreach statement declaration.
         /// </summary>
-        private readonly VariableDeclarationExpression variable;
+        private readonly Expression variable;
 
         /// <summary>
         /// The statement that is embedded within this foreach statement.
@@ -51,17 +51,21 @@ namespace StyleCop.CSharp
         /// The list of tokens that form the statement.
         /// </param>
         /// <param name="variable">
-        /// The variable declared in for each statement declaration.
+        /// The variable or tuple type, declared in for each statement declaration.
         /// </param>
         /// <param name="item">
         /// The item being iterated over.
         /// </param>
-        internal ForeachStatement(CsTokenList tokens, VariableDeclarationExpression variable, Expression item)
+        internal ForeachStatement(CsTokenList tokens, Expression variable, Expression item)
             : base(StatementType.Foreach, tokens)
         {
             Param.AssertNotNull(tokens, "tokens");
             Param.AssertNotNull(variable, "variable");
             Param.AssertNotNull(item, "item");
+            Param.Assert(
+                variable.ExpressionType == ExpressionType.VariableDeclaration || variable.ExpressionType == ExpressionType.Tuple, 
+                nameof(variable), 
+                "variable must be of type VariableDeclaration or Tuple");
 
             this.variable = variable;
             this.item = item;
@@ -104,9 +108,9 @@ namespace StyleCop.CSharp
         }
 
         /// <summary>
-        /// Gets the variable declared in the foreach statement declaration.
+        /// Gets the variable or tuple type, declared in the foreach statement declaration.
         /// </summary>
-        public VariableDeclarationExpression Variable
+        public Expression Variable
         {
             get
             {

--- a/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Spacing/CloseParenthesis.cs
+++ b/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Spacing/CloseParenthesis.cs
@@ -144,5 +144,14 @@ null;
         public static void Test<T>(T value = default(T) )
         {
         }
+
+        public void TestForIssue141()
+        {
+            List<(string, int)> listOfTuple = new List<(string, int)>();
+
+            // The following should raise a violation
+            List<(string, int) > listOfTuple1;
+            List<(string, int )> listOfTuple1;
+        }
     }
 }

--- a/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Spacing/OpenParenthesis.cs
+++ b/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Spacing/OpenParenthesis.cs
@@ -49,5 +49,11 @@ namespace CSharpAnalyzersTest.TestData.Spacing
             {
             }
         }
+
+        public void TestForTupleDeconstruction()
+        {
+            var (firstName, lastName) = Person;
+            var ( firstN, lastN) = Person; // Should throw violation.
+        }
     }
 }

--- a/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Spacing/TestDescription.xml
+++ b/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Spacing/TestDescription.xml
@@ -291,6 +291,14 @@
       <Violation Section="Root.CSharpAnalyzersTest.TestData.Spacing.OpenParenthesis.TestForIssue133" 
                  LineNumber="48" 
                  Rule="ClosingParenthesisMustBeSpacedCorrectly" />
+      <Violation Section="Root.CloseParenthesisSpacing.Class21.TestForIssue141" 
+                 LineNumber="153"
+                 Rule="ClosingParenthesisMustBeSpacedCorrectly" />
+      <Violation Section="Root.CloseParenthesisSpacing.Class21.TestForIssue141" LineNumber="154"
+                 Rule="ClosingParenthesisMustBeSpacedCorrectly" />
+      <Violation Section="Root.CSharpAnalyzersTest.TestData.Spacing.OpenParenthesis.TestForTupleDeconstruction"
+                 LineNumber="56" 
+                 Rule="OpeningParenthesisMustBeSpacedCorrectly" />
     </ExpectedViolations>
   </Test>
   <Test Name="CloseCurlyBracket">

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
@@ -466,6 +466,17 @@ public class Class8<T, S>
             {
             }
         }
+
+        public void LocalFunctionWithFullyQualifiedReturnType()
+        {
+            Ns1.Type Func1()
+            {
+            }
+
+            Ns1.Ns2.Type Func2()
+            {
+            }
+        }
     }
 
 #endregion

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
@@ -644,6 +644,10 @@ public class Class8<T, S>
             {
             }
         }
+
+        public (int a, string b)? NullableTupleReturnType()
+        {
+        }
     }
 
 #endregion

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
@@ -442,8 +442,28 @@ public class Class8<T, S>
         public void LocalFunctionWithTypeConstraint<T>()
         {            
             T LocalFunction<T>() where T : Person
+            {            
+            }
+        }
+
+        public void LocalFunctionWithNullableReturn()
+        {
+            bool? Check(object target)
             {
-            
+            }
+        }
+
+        public async Task AsyncLocalFunction()
+        {
+            async Task Wait()
+            {
+            }
+        }
+
+        public async Task AsyncLocalFunctionWithReturnValue()
+        {
+            async Task<int> WaitInt()
+            {
             }
         }
     }
@@ -452,7 +472,7 @@ public class Class8<T, S>
 
 #region Out Variables
 
-    public class OutVariables
+public class OutVariables
     {
         public void PrintCoordinates(Point p)
         {

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/Method.cs
@@ -483,7 +483,7 @@ public class Class8<T, S>
 
 #region Out Variables
 
-public class OutVariables
+    public class OutVariables
     {
         public void PrintCoordinates(Point p)
         {
@@ -632,7 +632,18 @@ public class OutVariables
             var (fname, lname) = person;
 
             var (_, lname) = person;
+        }
+
+        public void TupleEnumerationTest(IEnumerable<(string, int)> words)
+        {
+            foreach ((string word, int count) in words)
+            {
+            }
+
+            foreach (var (word, count) in words)
+            {
+            }
+        }
     }
-}
 
 #endregion

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
@@ -1323,7 +1323,45 @@
             </Expression>
             <Expression Text="person" Type="LiteralExpression" />
           </Expression>
-        </Statement>        
+        </Statement>
+      </Element>
+      <Element Name="TupleEnumerationTest" Type="Method">
+        <Statement Type="ForeachStatement">
+          <Expression Type="TupleExpression">
+            <Expression Type="VariableDeclarationExpression">
+              <Expression Text="string" Type="LiteralExpression" />
+              <Expression Type="VariableDeclaratorExpression">
+                <Expression Text="word" Type="LiteralExpression" />
+              </Expression>
+            </Expression>
+            <Expression Type="VariableDeclarationExpression">
+              <Expression Text="int" Type="LiteralExpression" />
+              <Expression Type="VariableDeclaratorExpression">
+                <Expression Text="count" Type="LiteralExpression" />
+              </Expression>
+            </Expression>
+          </Expression>
+          <Expression Text="words" Type="LiteralExpression" />
+          <Statement Type="BlockStatement" />
+        </Statement>
+        <Statement Type="ForeachStatement">
+          <Expression Type="TupleExpression">
+            <Expression Type="VariableDeclarationExpression">
+              <Expression Text="var" Type="LiteralExpression" />
+              <Expression Type="VariableDeclaratorExpression">
+                <Expression Text="word" Type="LiteralExpression" />
+              </Expression>
+            </Expression>
+            <Expression Type="VariableDeclarationExpression">
+              <Expression Text="var" Type="LiteralExpression" />
+              <Expression Type="VariableDeclaratorExpression">
+                <Expression Text="count" Type="LiteralExpression" />
+              </Expression>
+            </Expression>
+          </Expression>
+          <Expression Text="words" Type="LiteralExpression" />
+          <Statement Type="BlockStatement" />
+        </Statement>
       </Element>
     </Element>
   </Element>

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
@@ -1363,6 +1363,7 @@
           <Statement Type="BlockStatement" />
         </Statement>
       </Element>
+      <Element Name="NullableTupleReturnType" Type="Method" />
     </Element>
   </Element>
 </StyleCopCsParserObjectModel>

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
@@ -703,6 +703,16 @@
           <Statement Type="BlockStatement" />
         </Statement>
       </Element>
+      <Element Name="LocalFunctionWithFullyQualifiedReturnType" Type="Method">
+        <Statement Type="LocalFunctionStatement">
+          <Expression Text="Func1" Type="LiteralExpression" />
+          <Statement Type="BlockStatement" />
+        </Statement>
+        <Statement Type="LocalFunctionStatement">
+          <Expression Text="Func2" Type="LiteralExpression" />
+          <Statement Type="BlockStatement" />
+        </Statement>
+      </Element>
     </Element>
     <Element Name="OutVariables" Type="Class">
       <Element Name="PrintCoordinates" Type="Method">

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Elements/MethodObjectModel.xml
@@ -685,6 +685,24 @@
           <Statement Type="BlockStatement" />
         </Statement>
       </Element>
+      <Element Name="LocalFunctionWithNullableReturn" Type="Method">
+        <Statement Type="LocalFunctionStatement">
+          <Expression Text="Check" Type="LiteralExpression" />
+          <Statement Type="BlockStatement" />
+        </Statement>
+      </Element>
+      <Element Name="AsyncLocalFunction" Type="Method">
+        <Statement Type="LocalFunctionStatement">
+          <Expression Text="Wait" Type="LiteralExpression" />
+          <Statement Type="BlockStatement" />
+        </Statement>
+      </Element>
+      <Element Name="AsyncLocalFunctionWithReturnValue" Type="Method">
+        <Statement Type="LocalFunctionStatement">
+          <Expression Text="WaitInt" Type="LiteralExpression" />
+          <Statement Type="BlockStatement" />
+        </Statement>
+      </Element>
     </Element>
     <Element Name="OutVariables" Type="Class">
       <Element Name="PrintCoordinates" Type="Method">

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/PatternMatch/PatternMatch.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/PatternMatch/PatternMatch.cs
@@ -68,6 +68,8 @@
                     break;
                 case Rectangle r:
                     break;
+                case shape.Something when someBoolean:
+                    break;
                 case IEnumerable<int> ieInt:
                     break;
                 default:

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/PatternMatch/PatternMatchObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/PatternMatch/PatternMatchObjectModel.xml
@@ -298,6 +298,14 @@
               <Statement Type="BreakStatement" />
             </Statement>
             <Statement Type="SwitchCaseStatement">
+              <Expression Type="MemberAccessExpression">
+                <Expression Text="shape" Type="LiteralExpression" />
+                <Expression Text="Something" Type="LiteralExpression" />
+              </Expression>
+              <Expression Text="someBoolean" Type="LiteralExpression" />
+              <Statement Type="BreakStatement" />
+            </Statement>            
+            <Statement Type="SwitchCaseStatement">
               <Expression Text="IEnumerable&lt;int&gt;" Type="LiteralExpression" />
               <Expression Text="ieInt" Type="LiteralExpression" />
               <Statement Type="BreakStatement" />

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/QueryExpressions/QueryExpressions.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/QueryExpressions/QueryExpressions.cs
@@ -85,6 +85,9 @@ namespace StyleCop.CSharpParserTest.TestData
             // Bug 6711 This was failing because the check for casting thought b.Equals was a cast of select
             var a = (from b in new int[] { 1, 2, 3, 4, 5}
             where true != (b.Equals)select b).First();
+
+            // Issue 171, Regression from handling pattern matching
+            result = (from p in layout.Elements where p is IMetaPropertyLink select (IMetaPropertyLink)p).ToList();
         }
     }
 }

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/QueryExpressions/QueryExpressionsObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/QueryExpressions/QueryExpressionsObjectModel.xml
@@ -251,7 +251,7 @@
               </Expression>
             </Expression>
           </Statement>
-<Statement Type="VariableDeclarationStatement">
+          <Statement Type="VariableDeclarationStatement">
             <Expression Type="VariableDeclarationExpression">
               <Expression Text="var" Type="LiteralExpression" />
               <Expression Type="VariableDeclaratorExpression">
@@ -328,7 +328,33 @@
                 </Expression>
               </Expression>
             </Expression>
-          </Statement> 
+          </Statement>
+          <Statement Type="ExpressionStatement">
+            <Expression Type="AssignmentExpression">
+              <Expression Text="result" Type="LiteralExpression" />
+              <Expression Type="MethodInvocationExpression">
+                <Expression Type="MemberAccessExpression">
+                  <Expression Type="ParenthesizedExpression">
+                    <Expression Type="QueryExpression">
+                      <Expression Type="MemberAccessExpression">
+                        <Expression Text="layout" Type="LiteralExpression" />
+                        <Expression Text="Elements" Type="LiteralExpression" />
+                      </Expression>
+                      <Expression Type="IsExpression">
+                        <Expression Text="p" Type="LiteralExpression" />
+                        <Expression Text="IMetaPropertyLink" Type="LiteralExpression" />
+                      </Expression>
+                      <Expression Type="CastExpression">
+                        <Expression Text="IMetaPropertyLink" Type="LiteralExpression" />
+                        <Expression Text="p" Type="LiteralExpression" />
+                      </Expression>
+                    </Expression>
+                  </Expression>
+                  <Expression Text="ToList" Type="LiteralExpression" />
+                </Expression>
+              </Expression>
+            </Expression>
+          </Statement>
         </Element>
       </Element>
     </Element>

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Strings/Strings.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Strings/Strings.cs
@@ -144,5 +144,7 @@ form
         var foo3 = $@"{foo2}\";
         // Regression check: Non-verbatim interpolated string ending with backslash
         var foo4 = $"{foo2}\\";
+
+        var issue192 = $"123 {@"c:\temp\"}";
     }
 }

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/Strings/StringsObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/Strings/StringsObjectModel.xml
@@ -526,6 +526,17 @@
             </Expression>
           </Statement>
         </Element>
+        <Element Name="issue192" Type="Field">
+          <Statement Type="VariableDeclarationStatement">
+            <Expression Type="VariableDeclarationExpression">
+              <Expression Text="var" Type="LiteralExpression" />
+              <Expression Type="VariableDeclaratorExpression">
+                <Expression Text="issue192" Type="LiteralExpression" />
+                <Expression Text="$&quot;123 {@&quot;c:\temp\&quot;}&quot;" Type="LiteralExpression" />
+              </Expression>
+            </Expression>
+          </Statement>
+        </Element>
       </Element>
     </Element>
   </Element>


### PR DESCRIPTION
- Fix parsing of async local functions. (#193)
- Fix bug in parsing of interpolated strings that contains verbatim strings in interpolated expressions. (#192)
- Fix parsing of local functions that declare fully qualified return types.(#191)
- Fix parsing of variables in ForEach statement, when enumerating tuples. (#179)
- Fix regression in parsing QueryExpressions. (#171)
- Fix bug in parsing switch case statements. (#154)
- Fix false spacing rule violations when using tuples in generic types, and in deconstruction statements. (#141)
- Fix parsing of nullable tuple types (#163)