### PR TITLE
Add support for empty default literal expressions from c# 7.1

### DIFF
--- a/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
@@ -1664,23 +1664,32 @@ namespace StyleCop.CSharp
             // Get the default keyword.
             Node<CsToken> firstTokenNode = this.tokens.InsertLast(this.GetToken(CsTokenType.DefaultValue, SymbolType.Default, parentReference, expressionReference));
 
-            // The next symbol will be the opening parenthesis.
-            Bracket openParenthesis = this.GetBracketToken(CsTokenType.OpenParenthesis, SymbolType.OpenParenthesis, expressionReference);
-            Node<CsToken> openParenthesisNode = this.tokens.InsertLast(openParenthesis);
+            LiteralExpression typeTokenExpression = null;
 
-            // Get the inner expression.
-            LiteralExpression typeTokenExpression = this.GetTypeTokenExpression(expressionReference, unsafeCode, true);
-            if (typeTokenExpression == null)
+            // The next symbol must be an opening curly bracket.
+            Symbol symbol = this.GetNextSymbol(expressionReference);
+
+            if (symbol.SymbolType == SymbolType.OpenParenthesis)
             {
+              // The next symbol will be the opening parenthesis.
+              Bracket openParenthesis = this.GetBracketToken(CsTokenType.OpenParenthesis, SymbolType.OpenParenthesis, expressionReference);
+              Node<CsToken> openParenthesisNode = this.tokens.InsertLast(openParenthesis);
+
+              // Get the inner expression.
+              typeTokenExpression = this.GetTypeTokenExpression(expressionReference, unsafeCode, false);
+
+              if (typeTokenExpression == null)
+              {
                 throw this.CreateSyntaxException();
+              }
+
+              // Get the closing parenthesis.
+              Bracket closeParenthesis = this.GetBracketToken(CsTokenType.CloseParenthesis, SymbolType.CloseParenthesis, expressionReference);
+              Node<CsToken> closeParenthesisNode = this.tokens.InsertLast(closeParenthesis);
+
+              openParenthesis.MatchingBracketNode = closeParenthesisNode;
+              closeParenthesis.MatchingBracketNode = openParenthesisNode;
             }
-
-            // Get the closing parenthesis.
-            Bracket closeParenthesis = this.GetBracketToken(CsTokenType.CloseParenthesis, SymbolType.CloseParenthesis, expressionReference);
-            Node<CsToken> closeParenthesisNode = this.tokens.InsertLast(closeParenthesis);
-
-            openParenthesis.MatchingBracketNode = closeParenthesisNode;
-            closeParenthesis.MatchingBracketNode = openParenthesisNode;
 
             // Create the token list for the method invocation expression.
             CsTokenList partialTokens = new CsTokenList(this.tokens, firstTokenNode, this.tokens.Last);

--- a/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
@@ -1671,24 +1671,24 @@ namespace StyleCop.CSharp
 
             if (symbol.SymbolType == SymbolType.OpenParenthesis)
             {
-              // The next symbol will be the opening parenthesis.
-              Bracket openParenthesis = this.GetBracketToken(CsTokenType.OpenParenthesis, SymbolType.OpenParenthesis, expressionReference);
-              Node<CsToken> openParenthesisNode = this.tokens.InsertLast(openParenthesis);
+                // The next symbol will be the opening parenthesis.
+                Bracket openParenthesis = this.GetBracketToken(CsTokenType.OpenParenthesis, SymbolType.OpenParenthesis, expressionReference);
+                Node<CsToken> openParenthesisNode = this.tokens.InsertLast(openParenthesis);
 
-              // Get the inner expression.
-              typeTokenExpression = this.GetTypeTokenExpression(expressionReference, unsafeCode, false);
+                // Get the inner expression.
+                typeTokenExpression = this.GetTypeTokenExpression(expressionReference, unsafeCode, false);
 
-              if (typeTokenExpression == null)
-              {
-                throw this.CreateSyntaxException();
-              }
+                if (typeTokenExpression == null)
+                {
+                    throw this.CreateSyntaxException();
+                }
 
-              // Get the closing parenthesis.
-              Bracket closeParenthesis = this.GetBracketToken(CsTokenType.CloseParenthesis, SymbolType.CloseParenthesis, expressionReference);
-              Node<CsToken> closeParenthesisNode = this.tokens.InsertLast(closeParenthesis);
+                // Get the closing parenthesis.
+                Bracket closeParenthesis = this.GetBracketToken(CsTokenType.CloseParenthesis, SymbolType.CloseParenthesis, expressionReference);
+                Node<CsToken> closeParenthesisNode = this.tokens.InsertLast(closeParenthesis);
 
-              openParenthesis.MatchingBracketNode = closeParenthesisNode;
-              closeParenthesis.MatchingBracketNode = openParenthesisNode;
+                openParenthesis.MatchingBracketNode = closeParenthesisNode;
+                closeParenthesis.MatchingBracketNode = openParenthesisNode;
             }
 
             // Create the token list for the method invocation expression.

--- a/Project/Src/StyleCop.CSharp/Expressions/DefaultValueExpression.cs
+++ b/Project/Src/StyleCop.CSharp/Expressions/DefaultValueExpression.cs
@@ -57,11 +57,12 @@ namespace StyleCop.CSharp
             : base(ExpressionType.DefaultValue, tokens)
         {
             Param.AssertNotNull(tokens, "tokens");
+            Param.Ignore(type);
 
             if (type != null)
             {
-              this.type = CodeParser.ExtractTypeTokenFromLiteralExpression(type);
-              this.AddExpression(type);
+                this.type = CodeParser.ExtractTypeTokenFromLiteralExpression(type);
+                this.AddExpression(type);
             }
 
             this.parent = parent;

--- a/Project/Src/StyleCop.CSharp/Expressions/DefaultValueExpression.cs
+++ b/Project/Src/StyleCop.CSharp/Expressions/DefaultValueExpression.cs
@@ -57,10 +57,12 @@ namespace StyleCop.CSharp
             : base(ExpressionType.DefaultValue, tokens)
         {
             Param.AssertNotNull(tokens, "tokens");
-            Param.AssertNotNull(type, "type");
 
-            this.type = CodeParser.ExtractTypeTokenFromLiteralExpression(type);
-            this.AddExpression(type);
+            if (type != null)
+            {
+              this.type = CodeParser.ExtractTypeTokenFromLiteralExpression(type);
+              this.AddExpression(type);
+            }
 
             this.parent = parent;
         }

--- a/Project/Test/Tests.StyleCop.CSharp/ParserTests.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/ParserTests.cs
@@ -238,6 +238,18 @@ namespace CSharpParserTest
         public void CsParserTestPatternMatch()
         {
             this.RunTest("PatternMatch");
+        }   
+        
+        /// <summary>
+        /// The cs parser pattern match.
+        /// </summary>
+        [TestMethod]
+        [DeploymentItem("StyleCop.CSharp.Rules.dll")]
+        [DeploymentItem("Testing.StyleCop.CSharp.ParserDump.dll")]
+        [DeploymentItem("TestData\\DefaultLiteralExpressions", "DefaultLiteralExpressions")]
+        public void CsParserTestDefaultLiteralExpressions()
+        {
+            this.RunTest("DefaultLiteralExpressions");
         }
 
         /// <summary>

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/DefaultLiteralExpressions.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/DefaultLiteralExpressions.cs
@@ -10,6 +10,10 @@ namespace Tests.StyleCop.CSharp.TestData.DefaultLiteralExpressions
     public DefaultLiteralExpressions()
     {
       int id = default(int);
+
+      int? csharp6NullableId = default(int?);
+
+      int? nullableId = default;
     }
   }
 }

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/DefaultLiteralExpressions.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/DefaultLiteralExpressions.cs
@@ -5,15 +5,15 @@ using System.Text;
 
 namespace Tests.StyleCop.CSharp.TestData.DefaultLiteralExpressions
 {
-  public class DefaultLiteralExpressions
-  {
-    public DefaultLiteralExpressions()
+    public class DefaultLiteralExpressions
     {
-      int id = default(int);
+        public DefaultLiteralExpressions()
+        {
+            int id = default(int);
 
-      int? csharp6NullableId = default(int?);
+            int? csharp6NullableId = default(int?);
 
-      int? nullableId = default;
+            int? nullableId = default;
+        }
     }
-  }
 }

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/DefaultLiteralExpressions.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/DefaultLiteralExpressions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Tests.StyleCop.CSharp.TestData.DefaultLiteralExpressions
+{
+  public class DefaultLiteralExpressions
+  {
+    public DefaultLiteralExpressions()
+    {
+      int id = default(int);
+    }
+  }
+}

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/DefaultLiteralExpressionsObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/DefaultLiteralExpressionsObjectModel.xml
@@ -1,0 +1,25 @@
+﻿<StyleCopCsParserObjectModel>
+  <Element Name="Root" Type="DocumentRoot">
+    <Element Name="System" Type="UsingDirective" />
+    <Element Name="System.Collections.Generic" Type="UsingDirective" />
+    <Element Name="System.Linq" Type="UsingDirective" />
+    <Element Name="System.Text" Type="UsingDirective" />
+    <Element Name="Tests.StyleCop.CSharp.TestData.DefaultLiteralExpressions" Type="Namespace">
+      <Element Name="DefaultLiteralExpressions" Type="Class">
+        <Element Name="DefaultLiteralExpressions" Type="Constructor">
+          <Statement Type="VariableDeclarationStatement">
+            <Expression Type="VariableDeclarationExpression">
+              <Expression Text="int" Type="LiteralExpression" />
+              <Expression Type="VariableDeclaratorExpression">
+                <Expression Text="id" Type="LiteralExpression" />
+                <Expression Type="DefaultValueExpression">
+                  <Expression Text="int" Type="LiteralExpression" />
+                </Expression>
+              </Expression>
+            </Expression>
+          </Statement>
+        </Element>
+      </Element>
+    </Element>
+  </Element>
+</StyleCopCsParserObjectModel>

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/DefaultLiteralExpressionsObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/DefaultLiteralExpressionsObjectModel.xml
@@ -18,6 +18,26 @@
               </Expression>
             </Expression>
           </Statement>
+          <Statement Type="VariableDeclarationStatement">
+            <Expression Type="VariableDeclarationExpression">
+              <Expression Text="int?" Type="LiteralExpression" />
+              <Expression Type="VariableDeclaratorExpression">
+                <Expression Text="csharp6NullableId" Type="LiteralExpression" />
+                <Expression Type="DefaultValueExpression">
+                  <Expression Text="int?" Type="LiteralExpression" />
+                </Expression>
+              </Expression>
+            </Expression>
+          </Statement>
+          <Statement Type="VariableDeclarationStatement">
+            <Expression Type="VariableDeclarationExpression">
+              <Expression Text="int?" Type="LiteralExpression" />
+              <Expression Type="VariableDeclaratorExpression">
+                <Expression Text="nullableId" Type="LiteralExpression" />
+                <Expression Type="DefaultValueExpression" />
+              </Expression>
+            </Expression>
+          </Statement>
         </Element>
       </Element>
     </Element>

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/TestDescription.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/TestDescription.xml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<StyleCopTestDescription TestName="DefaultLiteralExpressions">
+  <Test Name="DefaultLiteralExpressions">
+    <TestCodeFile TestObjectModel="true">DefaultLiteralExpressions.cs</TestCodeFile>
+    <Settings>
+      <GlobalSettings>
+        <StringProperty Name="MergeSettingsFiles">NoMerge</StringProperty>
+        <BooleanProperty Name="RulesEnabledByDefault">False</BooleanProperty>
+      </GlobalSettings>
+      <Analyzers>
+        <Analyzer AnalyzerId="Testing.StyleCop.CSharp.ParserDump.CsParserDump">
+          <Rules>
+            <Rule Name="CsParserDumpRule">
+              <RuleSettings>
+                <BooleanProperty Name="Enabled">True</BooleanProperty>
+              </RuleSettings>
+            </Rule>
+          </Rules>
+        </Analyzer>
+      </Analyzers>
+    </Settings>
+  </Test>
+</StyleCopTestDescription>

--- a/Project/Test/Tests.StyleCop.CSharp/Tests.StyleCop.CSharp.csproj
+++ b/Project/Test/Tests.StyleCop.CSharp/Tests.StyleCop.CSharp.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-	<DebugType>full</DebugType>
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\TestBin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -52,6 +52,9 @@
   <ItemGroup>
     <Compile Include="ParserTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <None Include="TestData\DefaultLiteralExpressions\DefaultLiteralExpressions.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestData\PatternMatch\PatternMatch.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -458,6 +461,16 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="TestData\PatternMatch\TestDescription.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TestData\DefaultLiteralExpressions\TestDescription.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TestData\DefaultLiteralExpressions\DefaultLiteralExpressionsObjectModel.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
Fix: #172