### PR TITLE
VS2019 support for vsix

### DIFF
--- a/Project/Src/StyleCop.VisualStudio.VSIX/source.extension.vsixmanifest
+++ b/Project/Src/StyleCop.VisualStudio.VSIX/source.extension.vsixmanifest
@@ -14,18 +14,18 @@
         <Icon>StyleCop.ico</Icon>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[12.0,16.0)" />
-        <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[12.0,)" />
+        <InstallationTarget Version="[11.0,)" Id="Microsoft.VisualStudio.Pro" />
     </Installation>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="StyleCop.VisualStudio" Path="|StyleCop.VisualStudio;PkgdefProjectOutputGroup|" />
     </Assets>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor"
-                      Version="[11.0,16.0)"
+                      Version="[11.0,)"
                       DisplayName="Visual Studio core editor" />
         <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices"
-                      Version="[11.0,16.0)"
+                      Version="[11.0,)"
                       DisplayName="C# and Visual Basic" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
fix based on this doc: https://madskristensen.net/blog/how-to-upgrade-extensions-to-support-visual-studio-2019/

fixes #219 
fixes #205 