### PR TITLE
Fixes simple bug with default literals for array types.

### DIFF
--- a/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
@@ -1676,7 +1676,7 @@ namespace StyleCop.CSharp
                 Node<CsToken> openParenthesisNode = this.tokens.InsertLast(openParenthesis);
 
                 // Get the inner expression.
-                typeTokenExpression = this.GetTypeTokenExpression(expressionReference, unsafeCode, false);
+                typeTokenExpression = this.GetTypeTokenExpression(expressionReference, unsafeCode, true);
 
                 if (typeTokenExpression == null)
                 {

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/DefaultLiteralExpressions.cs
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/DefaultLiteralExpressions.cs
@@ -11,6 +11,8 @@ namespace Tests.StyleCop.CSharp.TestData.DefaultLiteralExpressions
         {
             int id = default(int);
 
+            int[] idArray = default(int[]);
+
             int? csharp6NullableId = default(int?);
 
             int? nullableId = default;

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/DefaultLiteralExpressionsObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/DefaultLiteralExpressions/DefaultLiteralExpressionsObjectModel.xml
@@ -20,6 +20,17 @@
           </Statement>
           <Statement Type="VariableDeclarationStatement">
             <Expression Type="VariableDeclarationExpression">
+              <Expression Text="int[]" Type="LiteralExpression" />
+              <Expression Type="VariableDeclaratorExpression">
+                <Expression Text="idArray" Type="LiteralExpression" />
+                <Expression Type="DefaultValueExpression">
+                  <Expression Text="int[]" Type="LiteralExpression" />
+                </Expression>
+              </Expression>
+            </Expression>
+          </Statement>
+          <Statement Type="VariableDeclarationStatement">
+            <Expression Type="VariableDeclarationExpression">
               <Expression Text="int?" Type="LiteralExpression" />
               <Expression Type="VariableDeclaratorExpression">
                 <Expression Text="csharp6NullableId" Type="LiteralExpression" />


### PR DESCRIPTION
When adding support for inferred types in default literals @hemnstill accidentally excluded square brackets form the type identification token which lead to a parsing error.

This change simply fixes that parameter and adds a test case for this scenario.