### PR TITLE
Fix #214: Detect dictionary array-like initializer subexpressions

### DIFF
--- a/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
+++ b/Project/Src/StyleCop.CSharp/CodeParser.Expressions.cs
@@ -1495,6 +1495,7 @@ namespace StyleCop.CSharp
 
             symbol = this.GetNextSymbol(expressionReference);
 
+            Expression declaration = null;
             if (symbol.SymbolType == SymbolType.Equals)
             {
                 // Get the equal operator.
@@ -1504,7 +1505,7 @@ namespace StyleCop.CSharp
                 // If it starts with an opening curly bracket, it's a statement, otherwise it's an expression.
                 symbol = this.GetNextSymbol(expressionReference);
 
-                Expression declaration = this.GetNextExpression(ExpressionPrecedence.None, expressionReference, unsafeCode);
+                declaration = this.GetNextExpression(ExpressionPrecedence.None, expressionReference, unsafeCode);
                 Symbol nextSymbol = this.GetNextSymbol(parentReference);
             }
 
@@ -1513,7 +1514,7 @@ namespace StyleCop.CSharp
             // Create the token list for the overall expression.
             CsTokenList expressionTokens = new CsTokenList(this.tokens, previousTokenNode, lastTokenNode);
             DictionaryItemInitializationExpression itemInitializationExpression
-                = new DictionaryItemInitializationExpression(expressionTokens);
+                = new DictionaryItemInitializationExpression(expressionTokens, declaration);
 
             // Return the expression.
             expressionReference.Target = itemInitializationExpression;

--- a/Project/Src/StyleCop.CSharp/Expressions/DictionaryItemInitializationExpression.cs
+++ b/Project/Src/StyleCop.CSharp/Expressions/DictionaryItemInitializationExpression.cs
@@ -32,10 +32,17 @@ namespace StyleCop.CSharp
         /// Initializes a new instance of the DictionaryItemInitializationExpression class.
         /// </summary>
         /// <param name="tokens">The list of tokens that form the statement.</param>
-        internal DictionaryItemInitializationExpression(CsTokenList tokens)
+        /// <param name="initializer">The initializer expression or null.</param>
+        internal DictionaryItemInitializationExpression(CsTokenList tokens, Expression initializer)
             : base(ExpressionType.ArrayInitializer, tokens)
         {
             Param.AssertNotNull(tokens, "tokens");
+            Param.Ignore(initializer);
+
+            if (initializer != null)
+            {
+                this.AddExpression(initializer);
+            }
         }
 
         #endregion

--- a/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Spacing/IndexInitializer.cs
+++ b/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Spacing/IndexInitializer.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Tests.StyleCop.CSharp.Rules.TestData.Spacing
+{
+    class IndexInitializer
+    {
+        static void InitializeInt()
+        {
+            var dict = new Dictionary<int, People>
+            {
+                [ 1 ] = new People( ),
+            };
+        }
+
+        public void InitializeString()
+        {
+            var dictionary = new Dictionary<string, string> { [ "key" ] = "value" };
+        }
+
+        private Dictionary<int, People> peoples = new Dictionary<int, People>
+        {
+            [3]=new People(){Name="test"},
+            [ 5 ] = new People( ) { Name = "test" },
+        };
+    }
+}

--- a/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Spacing/TestDescription.xml
+++ b/Project/Test/Tests.StyleCop.CSharp.Rules/TestData/Spacing/TestDescription.xml
@@ -895,4 +895,73 @@
                  Rule="SemicolonsMustBeSpacedCorrectly" />
     </ExpectedViolations>
   </Test>
+    <Test Name="IndexInitializer">
+        <TestCodeFile>IndexInitializer.cs</TestCodeFile>
+        <Settings>
+            <GlobalSettings>
+                <StringProperty Name="MergeSettingsFiles">NoMerge</StringProperty>
+                <BooleanProperty Name="RulesEnabledByDefault">False</BooleanProperty>
+            </GlobalSettings>
+            <Analyzers>
+                <Analyzer AnalyzerId="StyleCop.CSharp.SpacingRules">
+                    <Rules>
+                        <Rule Name="OpeningSquareBracketsMustBeSpacedCorrectly">
+                            <RuleSettings>
+                                <BooleanProperty Name="Enabled">True</BooleanProperty>
+                            </RuleSettings>
+                        </Rule>
+                        <Rule Name="ClosingSquareBracketsMustBeSpacedCorrectly">
+                            <RuleSettings>
+                                <BooleanProperty Name="Enabled">True</BooleanProperty>
+                            </RuleSettings>
+                        </Rule>
+                        <Rule Name="OpeningParenthesisMustBeSpacedCorrectly">
+                            <RuleSettings>
+                                <BooleanProperty Name="Enabled">True</BooleanProperty>
+                            </RuleSettings>
+                        </Rule>
+                        <Rule Name="ClosingParenthesisMustBeSpacedCorrectly">
+                            <RuleSettings>
+                                <BooleanProperty Name="Enabled">True</BooleanProperty>
+                            </RuleSettings>
+                        </Rule>
+                        <Rule Name="OpeningCurlyBracketsMustBeSpacedCorrectly">
+                            <RuleSettings>
+                                <BooleanProperty Name="Enabled">True</BooleanProperty>
+                            </RuleSettings>
+                        </Rule>
+                        <Rule Name="ClosingCurlyBracketsMustBeSpacedCorrectly">
+                            <RuleSettings>
+                                <BooleanProperty Name="Enabled">True</BooleanProperty>
+                            </RuleSettings>
+                        </Rule>
+                        <Rule Name="SymbolsMustBeSpacedCorrectly">
+                            <RuleSettings>
+                                <BooleanProperty Name="Enabled">True</BooleanProperty>
+                            </RuleSettings>
+                        </Rule>
+                    </Rules>
+                </Analyzer>
+            </Analyzers>
+        </Settings>
+        <ExpectedViolations>
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.InitializeInt" LineNumber="14" StartLine="14" StartColumn="17" EndLine="14" EndColumn="17" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="OpeningSquareBracketsMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.InitializeInt" LineNumber="14" StartLine="14" StartColumn="21" EndLine="14" EndColumn="21" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="ClosingSquareBracketsMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.InitializeInt" LineNumber="14" StartLine="14" StartColumn="36" EndLine="14" EndColumn="36" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="OpeningParenthesisMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.InitializeInt" LineNumber="14" StartLine="14" StartColumn="36" EndLine="14" EndColumn="36" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="ClosingParenthesisMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.InitializeString" LineNumber="20" StartLine="20" StartColumn="63" EndLine="20" EndColumn="63" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="OpeningSquareBracketsMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.InitializeString" LineNumber="20" StartLine="20" StartColumn="71" EndLine="20" EndColumn="71" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="ClosingSquareBracketsMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.peoples" LineNumber="25" StartLine="25" StartColumn="15" EndLine="25" EndColumn="15" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="ClosingSquareBracketsMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.peoples" LineNumber="25" StartLine="25" StartColumn="16" EndLine="25" EndColumn="16" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="SymbolsMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.peoples" LineNumber="25" StartLine="25" StartColumn="29" EndLine="25" EndColumn="29" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="ClosingParenthesisMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.peoples" LineNumber="25" StartLine="25" StartColumn="29" EndLine="25" EndColumn="29" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="OpeningCurlyBracketsMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.peoples" LineNumber="25" StartLine="25" StartColumn="34" EndLine="25" EndColumn="34" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="SymbolsMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.peoples" LineNumber="25" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="SymbolsMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.peoples" LineNumber="25" StartLine="25" StartColumn="41" EndLine="25" EndColumn="41" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="ClosingCurlyBracketsMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.peoples" LineNumber="26" StartLine="26" StartColumn="13" EndLine="26" EndColumn="13" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="OpeningSquareBracketsMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.peoples" LineNumber="26" StartLine="26" StartColumn="17" EndLine="26" EndColumn="17" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="ClosingSquareBracketsMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.peoples" LineNumber="26" StartLine="26" StartColumn="32" EndLine="26" EndColumn="32" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="OpeningParenthesisMustBeSpacedCorrectly" />
+            <Violation Section="Root.Tests.StyleCop.CSharp.Rules.TestData.Spacing.IndexInitializer.peoples" LineNumber="26" StartLine="26" StartColumn="32" EndLine="26" EndColumn="32" RuleNamespace="StyleCop.CSharp.SpacingRules" Rule="ClosingParenthesisMustBeSpacedCorrectly" />
+        </ExpectedViolations>
+    </Test>
 </StyleCopTestDescription>

--- a/Project/Test/Tests.StyleCop.CSharp.Rules/Tests.StyleCop.CSharp.Rules.csproj
+++ b/Project/Test/Tests.StyleCop.CSharp.Rules/Tests.StyleCop.CSharp.Rules.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-	<DebugType>full</DebugType>
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\TestBin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -52,6 +52,9 @@
   <ItemGroup>
     <Compile Include="AnalyzerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <None Include="TestData\Spacing\IndexInitializer.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="..\..\Src\StyleCop\mssp7en.lex">
       <Link>mssp7en.lex</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Project/Test/Tests.StyleCop.CSharp/TestData/IndexInitializer/IndexInitializersExpressionsObjectModel.xml
+++ b/Project/Test/Tests.StyleCop.CSharp/TestData/IndexInitializer/IndexInitializersExpressionsObjectModel.xml
@@ -11,9 +11,15 @@
                 <Expression Type="NewExpression">
                   <Expression Text="Dictionary&lt;string,int&gt;" Type="LiteralExpression" />
                   <Expression Type="CollectionInitializerExpression">
-                    <Expression Type="DictionaryItemInitializationExpression" />
-                    <Expression Type="DictionaryItemInitializationExpression" />
-                    <Expression Type="DictionaryItemInitializationExpression" />
+                    <Expression Type="DictionaryItemInitializationExpression">
+                      <Expression Text="1" Type="LiteralExpression" />
+                    </Expression>
+                    <Expression Type="DictionaryItemInitializationExpression">
+                      <Expression Text="2" Type="LiteralExpression" />
+                    </Expression>
+                    <Expression Type="DictionaryItemInitializationExpression">
+                      <Expression Text="3" Type="LiteralExpression" />
+                    </Expression>
                   </Expression>
                 </Expression>
               </Expression>
@@ -29,9 +35,15 @@
                 <Expression Type="NewExpression">
                   <Expression Text="Dictionary&lt;int,int&gt;" Type="LiteralExpression" />
                   <Expression Type="CollectionInitializerExpression">
-                    <Expression Type="DictionaryItemInitializationExpression" />
-                    <Expression Type="DictionaryItemInitializationExpression" />
-                    <Expression Type="DictionaryItemInitializationExpression" />
+                    <Expression Type="DictionaryItemInitializationExpression">
+                      <Expression Text="1" Type="LiteralExpression" />
+                    </Expression>
+                    <Expression Type="DictionaryItemInitializationExpression">
+                      <Expression Text="2" Type="LiteralExpression" />
+                    </Expression>
+                    <Expression Type="DictionaryItemInitializationExpression">
+                      <Expression Text="3" Type="LiteralExpression" />
+                    </Expression>
                   </Expression>
                 </Expression>
               </Expression>
@@ -47,9 +59,45 @@
                 <Expression Type="NewExpression">
                   <Expression Text="Dictionary&lt;int,People&gt;" Type="LiteralExpression" />
                   <Expression Type="CollectionInitializerExpression">
-                    <Expression Type="DictionaryItemInitializationExpression" />
-                    <Expression Type="DictionaryItemInitializationExpression" />
-                    <Expression Type="DictionaryItemInitializationExpression" />
+                    <Expression Type="DictionaryItemInitializationExpression">
+                      <Expression Type="NewExpression">
+                        <Expression Type="MethodInvocationExpression">
+                          <Expression Text="People" Type="LiteralExpression" />
+                        </Expression>
+                        <Expression Type="ObjectInitializerExpression">
+                          <Expression Type="AssignmentExpression">
+                            <Expression Text="Name" Type="LiteralExpression" />
+                            <Expression Text="&quot;test&quot;" Type="LiteralExpression" />
+                          </Expression>
+                        </Expression>
+                      </Expression>
+                    </Expression>
+                    <Expression Type="DictionaryItemInitializationExpression">
+                      <Expression Type="NewExpression">
+                        <Expression Type="MethodInvocationExpression">
+                          <Expression Text="People" Type="LiteralExpression" />
+                        </Expression>
+                        <Expression Type="ObjectInitializerExpression">
+                          <Expression Type="AssignmentExpression">
+                            <Expression Text="Name" Type="LiteralExpression" />
+                            <Expression Text="&quot;test&quot;" Type="LiteralExpression" />
+                          </Expression>
+                        </Expression>
+                      </Expression>
+                    </Expression>
+                    <Expression Type="DictionaryItemInitializationExpression">
+                      <Expression Type="NewExpression">
+                        <Expression Type="MethodInvocationExpression">
+                          <Expression Text="People" Type="LiteralExpression" />
+                        </Expression>
+                        <Expression Type="ObjectInitializerExpression">
+                          <Expression Type="AssignmentExpression">
+                            <Expression Text="Name" Type="LiteralExpression" />
+                            <Expression Text="&quot;test&quot;" Type="LiteralExpression" />
+                          </Expression>
+                        </Expression>
+                      </Expression>
+                    </Expression>
                   </Expression>
                 </Expression>
               </Expression>
@@ -65,7 +113,9 @@
                 <Expression Type="NewExpression">
                   <Expression Text="Dictionary&lt;int,int&gt;" Type="LiteralExpression" />
                   <Expression Type="CollectionInitializerExpression">
-                    <Expression Type="DictionaryItemInitializationExpression" />
+                    <Expression Type="DictionaryItemInitializationExpression">
+                      <Expression Text="0" Type="LiteralExpression" />
+                    </Expression>
                   </Expression>
                 </Expression>
               </Expression>
@@ -81,7 +131,9 @@
                 <Expression Type="NewExpression">
                   <Expression Text="Dictionary&lt;string,string&gt;" Type="LiteralExpression" />
                   <Expression Type="CollectionInitializerExpression">
-                    <Expression Type="DictionaryItemInitializationExpression" />
+                    <Expression Type="DictionaryItemInitializationExpression">
+                      <Expression Text="&quot;value&quot;" Type="LiteralExpression" />
+                    </Expression>
                   </Expression>
                 </Expression>
               </Expression>


### PR DESCRIPTION
#214 describes an argument null exception that we are also facing from time to time. The reason behind is that the passed expression does not have a parent code element.
To avoid this I am passing the actual initializing sub-expression as it is handled for similar expressions.

Regarding implementation:
* I'm not 100% sure if it may happen that the initializer expression is null. The code path looks like this, but we could also throw a parse exception in that case to avoid the null-check in the constructor.
* One of the asserted violation is just a line-location. I think this could be fixed in https://github.com/StyleCop/StyleCop/blob/master/Project/Src/StyleCop.CSharp.Rules/SpacingRules.cs#L1749 by passing the CodeLocation instead of LineNumer. But I don't want to mix in another fix.